### PR TITLE
Add sequenced serial ACK framing

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,7 +53,7 @@
 - 支持 `单色绘制` 与 `官方色绘制`
 - 支持 `256x256` 脚本坐标画布工作流
 - 支持 `自动扣背景`，适合白底、浅灰底、棋盘格假透明图
-- 通过串口将绘制脚本逐条发送给 ESP32，并等待 `ACK`
+- 通过带 `SEQ <session> <seq>` 去重帧的串口协议将绘制脚本逐条发送给 ESP32，并等待 `ACK`
 - 在网页中完成脚本生成、固件刷写、手柄连接与按钮测试，以及暂停、继续和中断绘制
 
 ### 整体架构
@@ -341,7 +341,7 @@ Reference documents:
 - Support both `mono drawing` and `official palette drawing`
 - Use a `256x256` script-coordinate canvas workflow
 - Support `automatic background removal` for white, light gray, and fake transparency checkerboard backgrounds
-- Send drawing commands to the ESP32 over serial and wait for `ACK`
+- Send drawing commands to the ESP32 over a `SEQ <session> <seq>` deduplicating serial protocol and wait for `ACK`
 - Handle script generation, firmware flashing, controller connection and button testing, plus pause, resume, and stop actions from the web interface
 
 ### Architecture

--- a/apps/desktop/src/protocol/sequencing.ts
+++ b/apps/desktop/src/protocol/sequencing.ts
@@ -1,0 +1,124 @@
+import { randomBytes } from "node:crypto";
+
+const SESSION_ID_RE = /^[0-9a-f]{8}$/iu;
+const SEQUENCE_RE = /^[1-9]\d*$/u;
+const OK_ACK_RE = /^OK\s+([0-9a-f]{8})\s+([1-9]\d*)$/iu;
+const ERR_ACK_RE = /^ERR\s+([0-9a-f]{8})\s+([1-9]\d*)\s+(.+)$/iu;
+const FRAME_RE = /^SEQ\s+([0-9a-f]{8})\s+([1-9]\d*)\s+(.+)$/iu;
+
+export interface SequencedFrame {
+  sessionId: string;
+  sequence: number;
+  command: string;
+}
+
+export type SequencedAck =
+  | {
+      type: "ok";
+      sessionId: string;
+      sequence: number;
+    }
+  | {
+      type: "err";
+      sessionId: string;
+      sequence: number;
+      message: string;
+    };
+
+function parseSequenceToken(value: string): number | null {
+  if (!SEQUENCE_RE.test(value)) {
+    return null;
+  }
+
+  const sequence = Number.parseInt(value, 10);
+  return Number.isSafeInteger(sequence) ? sequence : null;
+}
+
+function normalizeSessionId(value: string): string | null {
+  return SESSION_ID_RE.test(value) ? value.toLowerCase() : null;
+}
+
+export function createSessionId(): string {
+  return randomBytes(4).toString("hex");
+}
+
+export function formatSequencedCommand(
+  sessionId: string,
+  sequence: number,
+  command: string,
+): string {
+  const normalizedSessionId = normalizeSessionId(sessionId);
+  const trimmedCommand = command.trim();
+
+  if (!normalizedSessionId) {
+    throw new Error(`Invalid session id: ${sessionId}`);
+  }
+
+  if (!Number.isSafeInteger(sequence) || sequence <= 0) {
+    throw new Error(`Invalid sequence: ${sequence}`);
+  }
+
+  if (trimmedCommand.length === 0) {
+    throw new Error("Cannot frame an empty command.");
+  }
+
+  return `SEQ ${normalizedSessionId} ${sequence} ${trimmedCommand}`;
+}
+
+export function parseSequencedFrame(line: string): SequencedFrame | null {
+  const match = FRAME_RE.exec(line.trim());
+
+  if (!match?.[1] || !match[2] || !match[3]) {
+    return null;
+  }
+
+  const sessionId = normalizeSessionId(match[1]);
+  const sequence = parseSequenceToken(match[2]);
+  const command = match[3].trim();
+
+  if (!sessionId || sequence === null || command.length === 0) {
+    return null;
+  }
+
+  return {
+    sessionId,
+    sequence,
+    command,
+  };
+}
+
+export function parseSequencedAck(line: string): SequencedAck | null {
+  const cleanLine = line.trim();
+  const okMatch = OK_ACK_RE.exec(cleanLine);
+
+  if (okMatch?.[1] && okMatch[2]) {
+    const sessionId = normalizeSessionId(okMatch[1]);
+    const sequence = parseSequenceToken(okMatch[2]);
+
+    if (sessionId && sequence !== null) {
+      return {
+        type: "ok",
+        sessionId,
+        sequence,
+      };
+    }
+  }
+
+  const errMatch = ERR_ACK_RE.exec(cleanLine);
+
+  if (errMatch?.[1] && errMatch[2] && errMatch[3]) {
+    const sessionId = normalizeSessionId(errMatch[1]);
+    const sequence = parseSequenceToken(errMatch[2]);
+
+    if (sessionId && sequence !== null) {
+      return {
+        type: "err",
+        sessionId,
+        sequence,
+        message: errMatch[3].trim(),
+      };
+    }
+  }
+
+  return null;
+}

--- a/apps/desktop/src/serial/sender.ts
+++ b/apps/desktop/src/serial/sender.ts
@@ -4,9 +4,15 @@ import { ReadlineParser } from "@serialport/parser-readline";
 import { SerialPort } from "serialport";
 
 import { preferSerialPath } from "./listPorts.js";
+import {
+  createSessionId,
+  formatSequencedCommand,
+  parseSequencedAck,
+} from "../protocol/sequencing.js";
 import type { ProgressUpdate, SenderControls } from "../types.js";
 
-const DEVICE_LINE_PREFIXES = ["INFO ", "WARN ", "ERR ", "BOOT ", "rst:"] as const;
+const ACK_LINE_PREFIXES = ["OK ", "ERR "] as const;
+const DEVICE_LINE_PREFIXES = ["INFO ", "WARN ", "BOOT ", "rst:"] as const;
 
 async function waitForOpen(port: SerialPort): Promise<void> {
   if (port.isOpen) {
@@ -17,7 +23,7 @@ async function waitForOpen(port: SerialPort): Promise<void> {
 }
 
 function isRecognizedDeviceLine(line: string): boolean {
-  if (line === "OK" || line.startsWith("ERR")) {
+  if (line === "OK" || line === "ERR" || ACK_LINE_PREFIXES.some((prefix) => line.startsWith(prefix))) {
     return true;
   }
 
@@ -39,7 +45,8 @@ function sanitizeDeviceLine(rawLine: string | Buffer): string | null {
     return cleanText;
   }
 
-  const candidateIndexes = DEVICE_LINE_PREFIXES.map((prefix) => cleanText.lastIndexOf(prefix))
+  const candidateIndexes = [...ACK_LINE_PREFIXES, ...DEVICE_LINE_PREFIXES]
+    .map((prefix) => cleanText.lastIndexOf(prefix))
     .filter((index) => index >= 0);
 
   if (candidateIndexes.length === 0) {
@@ -54,6 +61,10 @@ function waitForAck(
   parser: ReadlineParser,
   port: SerialPort,
   timeoutMs: number,
+  expected: {
+    sessionId: string;
+    sequence: number;
+  },
   options?: {
     onDeviceLine?: (line: string) => void;
     onInterruptReady?: (interrupt: (() => void) | null) => void;
@@ -88,13 +99,33 @@ function waitForAck(
         return;
       }
 
-      if (line === "OK") {
-        finish(() => resolve("OK"));
+      const ack = parseSequencedAck(line);
+
+      if (ack) {
+        if (ack.sessionId !== expected.sessionId || ack.sequence !== expected.sequence) {
+          options?.onDeviceLine?.(
+            `WARN ignored ack session=${ack.sessionId} seq=${ack.sequence} expected=${expected.sessionId}:${expected.sequence}`,
+          );
+          return;
+        }
+
+        if (ack.type === "ok") {
+          finish(() => resolve("OK"));
+          return;
+        }
+
+        finish(() => reject(new Error(`Device returned ERR ${ack.sessionId} ${ack.sequence} ${ack.message}`)));
         return;
       }
 
-      if (line.startsWith("ERR")) {
-        finish(() => reject(new Error(`Device returned ${line}`)));
+      if (line === "OK" || line === "ERR" || line.startsWith("OK ") || line.startsWith("ERR ")) {
+        finish(() =>
+          reject(
+            new Error(
+              `Device returned an unsequenced or malformed ACK: ${line}. Reflash the ESP32 firmware for the SEQ protocol.`,
+            ),
+          ),
+        );
         return;
       }
 
@@ -256,6 +287,8 @@ export class SerialAckSender implements SenderControls {
     this.activePort = port;
 
     const parser = port.pipe(new ReadlineParser({ delimiter: "\n" }));
+    const sessionId = createSessionId();
+    let sequence = 1;
 
     try {
       await waitForOpen(port);
@@ -269,14 +302,20 @@ export class SerialAckSender implements SenderControls {
 
         let attempt = 0;
         let sent = false;
+        const commandSequence = sequence;
+        const framedCommand = formatSequencedCommand(sessionId, commandSequence, command);
 
         while (!sent) {
           try {
-            await writeLine(port, command);
+            await writeLine(port, framedCommand);
             await waitForAck(
               parser,
               port,
               getAckTimeoutForCommand(command, options.ackTimeoutMs),
+              {
+                sessionId,
+                sequence: commandSequence,
+              },
               {
                 ...(options.onDeviceLine ? { onDeviceLine: options.onDeviceLine } : {}),
                 onInterruptReady: (interrupt) => {
@@ -307,10 +346,11 @@ export class SerialAckSender implements SenderControls {
           total: commands.length,
           command,
         });
+        sequence += 1;
       }
 
       if (this.stopped && port.isOpen) {
-        await writeLine(port, "E");
+        await writeLine(port, formatSequencedCommand(sessionId, sequence, "E"));
       }
     } finally {
       this.interruptAckWait = null;

--- a/apps/desktop/src/simulator/device.ts
+++ b/apps/desktop/src/simulator/device.ts
@@ -1,3 +1,5 @@
+import { parseSequencedFrame, type SequencedFrame } from "../protocol/sequencing.js";
+
 function parseTwoInts(line: string): { first: number; second: number } | null {
   const parts = line.trim().split(/\s+/u);
 
@@ -31,7 +33,7 @@ function delay(ms: number): Promise<void> {
 }
 
 export interface SimulatedDeviceResponse {
-  ack: "OK" | `ERR ${string}`;
+  ack: string;
   lines: string[];
 }
 
@@ -42,6 +44,13 @@ interface SimulatedDeviceState {
   drawCount: number;
   paused: boolean;
   ended: boolean;
+}
+
+interface SequencedDeviceState {
+  sessionId: string | null;
+  lastSequence: number;
+  lastCommand: string;
+  lastAck: string;
 }
 
 export class SimulatedDevice {
@@ -55,6 +64,80 @@ export class SimulatedDevice {
     paused: false,
     ended: false,
   };
+  private sequenceState: SequencedDeviceState = {
+    sessionId: null,
+    lastSequence: 0,
+    lastCommand: "",
+    lastAck: "",
+  };
+
+  private makeAck(frame: SequencedFrame): string {
+    return `OK ${frame.sessionId} ${frame.sequence}`;
+  }
+
+  private makeError(frame: SequencedFrame, message: string): string {
+    return `ERR ${frame.sessionId} ${frame.sequence} ${message}`;
+  }
+
+  private cacheAndReturn(
+    frame: SequencedFrame,
+    ack: string,
+    lines: string[],
+  ): SimulatedDeviceResponse {
+    this.sequenceState.lastSequence = frame.sequence;
+    this.sequenceState.lastCommand = frame.command;
+    this.sequenceState.lastAck = ack;
+
+    return {
+      ack,
+      lines,
+    };
+  }
+
+  private validateFrame(frame: SequencedFrame): SimulatedDeviceResponse | null {
+    if (this.sequenceState.sessionId !== frame.sessionId) {
+      if (frame.sequence !== 1) {
+        return {
+          ack: this.makeError(frame, "sequence expected 1 for new session"),
+          lines: [],
+        };
+      }
+
+      this.sequenceState = {
+        sessionId: frame.sessionId,
+        lastSequence: 0,
+        lastCommand: "",
+        lastAck: "",
+      };
+      return null;
+    }
+
+    if (frame.sequence === this.sequenceState.lastSequence) {
+      if (frame.command === this.sequenceState.lastCommand && this.sequenceState.lastAck) {
+        return {
+          ack: this.sequenceState.lastAck,
+          lines: [],
+        };
+      }
+
+      return {
+        ack: this.makeError(frame, "duplicate sequence command mismatch"),
+        lines: [],
+      };
+    }
+
+    if (frame.sequence !== this.sequenceState.lastSequence + 1) {
+      return {
+        ack: this.makeError(
+          frame,
+          `sequence expected ${this.sequenceState.lastSequence + 1}`,
+        ),
+        lines: [],
+      };
+    }
+
+    return null;
+  }
 
   async executeCommand(
     line: string,
@@ -64,7 +147,24 @@ export class SimulatedDevice {
       errorAtCommand?: number;
     },
   ): Promise<SimulatedDeviceResponse> {
-    const trimmed = line.trim();
+    const frame = parseSequencedFrame(line);
+
+    if (!frame) {
+      await delay(options.ackDelayMs);
+      return {
+        ack: "ERR protocol frame required",
+        lines: [],
+      };
+    }
+
+    const sequenceResult = this.validateFrame(frame);
+
+    if (sequenceResult) {
+      await delay(options.ackDelayMs);
+      return sequenceResult;
+    }
+
+    const trimmed = frame.command;
     const lines: string[] = [];
 
     if (
@@ -75,14 +175,14 @@ export class SimulatedDevice {
       this.injectedFailures.add(options.commandIndex);
       await delay(options.ackDelayMs);
       return {
-        ack: `ERR injected failure at command ${options.commandIndex}`,
+        ack: this.makeError(frame, `injected failure at command ${options.commandIndex}`),
         lines,
       };
     }
 
     if (trimmed.length === 0) {
       await delay(options.ackDelayMs);
-      return { ack: "OK", lines };
+      return this.cacheAndReturn(frame, this.makeAck(frame), lines);
     }
 
     if (trimmed === "I") {
@@ -90,34 +190,34 @@ export class SimulatedDevice {
         `INFO transport=${this.transportName} x=${this.state.x} y=${this.state.y} color=${this.state.colorIndex} draws=${this.state.drawCount}`,
       );
       await delay(options.ackDelayMs);
-      return { ack: "OK", lines };
+      return this.cacheAndReturn(frame, this.makeAck(frame), lines);
     }
 
     if (trimmed === "H") {
       this.state.x = 0;
       this.state.y = 0;
       await delay(options.ackDelayMs);
-      return { ack: "OK", lines };
+      return this.cacheAndReturn(frame, this.makeAck(frame), lines);
     }
 
     if (trimmed === "P") {
       this.state.drawCount += 1;
       await delay(options.ackDelayMs);
-      return { ack: "OK", lines };
+      return this.cacheAndReturn(frame, this.makeAck(frame), lines);
     }
 
     if (trimmed === "S") {
       this.state.paused = true;
       lines.push("INFO paused=true");
       await delay(options.ackDelayMs);
-      return { ack: "OK", lines };
+      return this.cacheAndReturn(frame, this.makeAck(frame), lines);
     }
 
     if (trimmed === "R") {
       this.state.paused = false;
       lines.push("INFO paused=false");
       await delay(options.ackDelayMs);
-      return { ack: "OK", lines };
+      return this.cacheAndReturn(frame, this.makeAck(frame), lines);
     }
 
     if (trimmed === "E") {
@@ -126,7 +226,7 @@ export class SimulatedDevice {
         `INFO end x=${this.state.x} y=${this.state.y} color=${this.state.colorIndex} draws=${this.state.drawCount}`,
       );
       await delay(options.ackDelayMs);
-      return { ack: "OK", lines };
+      return this.cacheAndReturn(frame, this.makeAck(frame), lines);
     }
 
     if (trimmed.startsWith("M ")) {
@@ -134,13 +234,13 @@ export class SimulatedDevice {
 
       if (!parsed) {
         await delay(options.ackDelayMs);
-        return { ack: "ERR invalid move", lines };
+        return this.cacheAndReturn(frame, this.makeError(frame, "invalid move"), lines);
       }
 
       this.state.x += parsed.first;
       this.state.y += parsed.second;
       await delay(options.ackDelayMs);
-      return { ack: "OK", lines };
+      return this.cacheAndReturn(frame, this.makeAck(frame), lines);
     }
 
     if (trimmed.startsWith("C ")) {
@@ -148,12 +248,12 @@ export class SimulatedDevice {
 
       if (colorIndex === null) {
         await delay(options.ackDelayMs);
-        return { ack: "ERR invalid color", lines };
+        return this.cacheAndReturn(frame, this.makeError(frame, "invalid color"), lines);
       }
 
       this.state.colorIndex = colorIndex;
       await delay(options.ackDelayMs);
-      return { ack: "OK", lines };
+      return this.cacheAndReturn(frame, this.makeAck(frame), lines);
     }
 
     if (trimmed.startsWith("W ")) {
@@ -161,19 +261,19 @@ export class SimulatedDevice {
 
       if (waitMs === null) {
         await delay(options.ackDelayMs);
-        return { ack: "ERR invalid wait", lines };
+        return this.cacheAndReturn(frame, this.makeError(frame, "invalid wait"), lines);
       }
 
       await delay(waitMs + options.ackDelayMs);
-      return { ack: "OK", lines };
+      return this.cacheAndReturn(frame, this.makeAck(frame), lines);
     }
 
     if (trimmed === "A" || trimmed === "B" || trimmed === "X" || trimmed === "Y") {
       await delay(options.ackDelayMs);
-      return { ack: "OK", lines };
+      return this.cacheAndReturn(frame, this.makeAck(frame), lines);
     }
 
     await delay(options.ackDelayMs);
-    return { ack: "ERR unknown command", lines };
+    return this.cacheAndReturn(frame, this.makeError(frame, "unknown command"), lines);
   }
 }

--- a/apps/desktop/src/simulator/sender.ts
+++ b/apps/desktop/src/simulator/sender.ts
@@ -1,4 +1,9 @@
 import type { ProgressUpdate, SenderControls } from "../types.js";
+import {
+  createSessionId,
+  formatSequencedCommand,
+  parseSequencedAck,
+} from "../protocol/sequencing.js";
 import { SimulatedDevice } from "./device.js";
 
 function delay(ms: number): Promise<void> {
@@ -58,6 +63,9 @@ export class SimulatedAckSender implements SenderControls {
       onDeviceLine?: (line: string) => void;
     },
   ): Promise<void> {
+    const sessionId = createSessionId();
+    let sequence = 1;
+
     for (const [index, command] of commands.entries()) {
       await this.waitWhilePaused();
 
@@ -67,10 +75,12 @@ export class SimulatedAckSender implements SenderControls {
 
       let attempt = 0;
       let sent = false;
+      const commandSequence = sequence;
+      const framedCommand = formatSequencedCommand(sessionId, commandSequence, command);
 
       while (!sent) {
         const response = await withTimeout(
-          this.device.executeCommand(command, {
+          this.device.executeCommand(framedCommand, {
             commandIndex: index + 1,
             ackDelayMs: options.ackDelayMs,
             ...(options.errorAtCommand !== undefined
@@ -84,7 +94,13 @@ export class SimulatedAckSender implements SenderControls {
           options.onDeviceLine?.(line);
         }
 
-        if (response.ack !== "OK") {
+        const ack = parseSequencedAck(response.ack);
+
+        if (!ack || ack.sessionId !== sessionId || ack.sequence !== commandSequence) {
+          throw new Error(`Device returned an invalid ACK: ${response.ack}`);
+        }
+
+        if (ack.type !== "ok") {
           if (attempt >= options.retries) {
             throw new Error(`Device returned ${response.ack}`);
           }
@@ -104,13 +120,17 @@ export class SimulatedAckSender implements SenderControls {
         total: commands.length,
         command,
       });
+      sequence += 1;
     }
 
     if (this.stopped) {
-      const response = await this.device.executeCommand("E", {
-        commandIndex: commands.length + 1,
-        ackDelayMs: options.ackDelayMs,
-      });
+      const response = await this.device.executeCommand(
+        formatSequencedCommand(sessionId, sequence, "E"),
+        {
+          commandIndex: commands.length + 1,
+          ackDelayMs: options.ackDelayMs,
+        },
+      );
 
       for (const line of response.lines) {
         options.onDeviceLine?.(line);

--- a/docs/arrival-checklist.md
+++ b/docs/arrival-checklist.md
@@ -59,7 +59,7 @@ npm run dev -- --commands-file ./examples/smoke-test-commands.txt --port <your-s
 Expected result:
 
 - the Mac CLI shows command progress
-- the board returns `OK` for each command
+- the board returns sequenced ACK lines such as `OK a1b2c3d4 1` for each command
 - the serial monitor prints `INFO transport=classic-bt-hid` when the `I` command runs
 - the `I` command also prints Bluetooth readiness fields such as `bt_hid_ready`, `bt_app_registered`, and `bt_discoverable`
 

--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -5,12 +5,13 @@
 - Confirm Node.js is at least 18.17
 - Re-run `npm install`
 
-## Serial port times out waiting for `OK`
+## Serial port times out waiting for `OK <session> <seq>`
 
 - Make sure the ESP32 firmware is flashed
 - Confirm the baud rate matches both sides
 - Use `npm run dev -- --list-ports` to verify the device path
-- Open a serial monitor and check whether the board prints `OK` after commands
+- Open a serial monitor and check whether the board prints sequenced ACK lines such as `OK a1b2c3d4 1`
+- Manual serial tests must send sequenced frames, for example `SEQ a1b2c3d4 1 I`; the CLI and Web UI wrap visible commands automatically
 - Start with `npm run dev -- --commands-file ./examples/smoke-test-commands.txt --port <device> --send` before trying full image streaming
 
 ## ESP32 board does not appear on macOS

--- a/firmware/esp32/src/main.cpp
+++ b/firmware/esp32/src/main.cpp
@@ -11,6 +11,20 @@
 
 namespace {
 
+struct SequencedFrame {
+  String sessionId;
+  uint32_t sequence = 0;
+  String command;
+};
+
+struct SequencedCommandCache {
+  bool hasSession = false;
+  String sessionId;
+  uint32_t lastSequence = 0;
+  String lastCommand;
+  String lastAckLine;
+};
+
 #if USE_MOCK_CONTROLLER
 MockControllerTransport mockTransport;
 ControllerTransport &transport = mockTransport;
@@ -20,6 +34,140 @@ ControllerTransport &transport = classicBtTransport;
 #endif
 
 SwitchController controller(transport);
+SequencedCommandCache sequencedCommandCache;
+
+bool isHexSessionId(const String &value) {
+  if (value.length() != 8) {
+    return false;
+  }
+
+  for (size_t index = 0; index < value.length(); index += 1) {
+    const char c = value.charAt(index);
+    const bool isHex =
+        (c >= '0' && c <= '9') || (c >= 'a' && c <= 'f') || (c >= 'A' && c <= 'F');
+
+    if (!isHex) {
+      return false;
+    }
+  }
+
+  return true;
+}
+
+bool parseSequenceToken(const String &value, uint32_t &sequence) {
+  if (value.length() == 0) {
+    return false;
+  }
+
+  uint32_t parsed = 0;
+
+  for (size_t index = 0; index < value.length(); index += 1) {
+    const char c = value.charAt(index);
+
+    if (c < '0' || c > '9') {
+      return false;
+    }
+
+    const uint32_t digit = static_cast<uint32_t>(c - '0');
+
+    if (parsed > (UINT32_MAX - digit) / 10) {
+      return false;
+    }
+
+    parsed = parsed * 10 + digit;
+  }
+
+  if (parsed == 0) {
+    return false;
+  }
+
+  sequence = parsed;
+  return true;
+}
+
+bool parseSequencedFrame(const String &line, SequencedFrame &frame) {
+  if (!line.startsWith("SEQ ")) {
+    return false;
+  }
+
+  const int firstSpace = line.indexOf(' ');
+  const int secondSpace = line.indexOf(' ', firstSpace + 1);
+  const int thirdSpace = line.indexOf(' ', secondSpace + 1);
+
+  if (secondSpace < 0 || thirdSpace < 0) {
+    return false;
+  }
+
+  String sessionId = line.substring(firstSpace + 1, secondSpace);
+  String sequenceToken = line.substring(secondSpace + 1, thirdSpace);
+  String command = line.substring(thirdSpace + 1);
+  command.trim();
+
+  if (!isHexSessionId(sessionId) || command.length() == 0) {
+    return false;
+  }
+
+  uint32_t sequence = 0;
+
+  if (!parseSequenceToken(sequenceToken, sequence)) {
+    return false;
+  }
+
+  sessionId.toLowerCase();
+  frame.sessionId = sessionId;
+  frame.sequence = sequence;
+  frame.command = command;
+  return true;
+}
+
+String makeOkAck(const SequencedFrame &frame) {
+  return "OK " + frame.sessionId + " " + String(frame.sequence);
+}
+
+String makeErrorAck(const SequencedFrame &frame, const String &message) {
+  return "ERR " + frame.sessionId + " " + String(frame.sequence) + " " + message;
+}
+
+bool validateSequencedFrame(const SequencedFrame &frame, String &ackLine) {
+  if (!sequencedCommandCache.hasSession || sequencedCommandCache.sessionId != frame.sessionId) {
+    if (frame.sequence != 1) {
+      ackLine = makeErrorAck(frame, "sequence expected 1 for new session");
+      return false;
+    }
+
+    sequencedCommandCache.hasSession = true;
+    sequencedCommandCache.sessionId = frame.sessionId;
+    sequencedCommandCache.lastSequence = 0;
+    sequencedCommandCache.lastCommand = "";
+    sequencedCommandCache.lastAckLine = "";
+    return true;
+  }
+
+  if (frame.sequence == sequencedCommandCache.lastSequence) {
+    if (frame.command == sequencedCommandCache.lastCommand &&
+        sequencedCommandCache.lastAckLine.length() > 0) {
+      ackLine = sequencedCommandCache.lastAckLine;
+      return false;
+    }
+
+    ackLine = makeErrorAck(frame, "duplicate sequence command mismatch");
+    return false;
+  }
+
+  if (frame.sequence != sequencedCommandCache.lastSequence + 1) {
+    ackLine = makeErrorAck(
+        frame, "sequence expected " + String(sequencedCommandCache.lastSequence + 1));
+    return false;
+  }
+
+  return true;
+}
+
+void cacheSequencedResult(const SequencedFrame &frame, const String &ackLine) {
+  sequencedCommandCache.lastSequence = frame.sequence;
+  sequencedCommandCache.lastCommand = frame.command;
+  sequencedCommandCache.lastAckLine = ackLine;
+}
 
 }  // namespace
 
@@ -43,14 +191,31 @@ void loop() {
   String line = Serial.readStringUntil('\n');
   line.trim();
 
-  String error;
-  const bool ok = executeCommand(line, controller, error);
+  SequencedFrame frame;
 
-  if (ok) {
-    Serial.println("OK");
+  if (!parseSequencedFrame(line, frame)) {
+    Serial.println("ERR protocol frame required");
     return;
   }
 
-  Serial.print("ERR ");
-  Serial.println(error);
+  String ackLine;
+
+  if (!validateSequencedFrame(frame, ackLine)) {
+    Serial.println(ackLine);
+    return;
+  }
+
+  String error;
+  const bool ok = executeCommand(frame.command, controller, error);
+
+  if (ok) {
+    ackLine = makeOkAck(frame);
+    cacheSequencedResult(frame, ackLine);
+    Serial.println(ackLine);
+    return;
+  }
+
+  ackLine = makeErrorAck(frame, error.length() > 0 ? error : "unknown error");
+  cacheSequencedResult(frame, ackLine);
+  Serial.println(ackLine);
 }


### PR DESCRIPTION
## Summary

- Add shared sequence framing helpers for desktop serial traffic.
- Require ACK messages to match the active sequence before advancing queued commands.
- Update the ESP32 firmware and simulator to parse sequence numbers and emit matching ACKs.
- Refresh protocol documentation with the new ACK examples.

## Validation

- `npm run check`
- `platformio --version` is not available in this local environment, so the firmware build was not run.