### PR TITLE
firmware: dual-mode serial protocol and Bluetooth improvements

### DIFF
--- a/firmware/esp32/.gitignore
+++ b/firmware/esp32/.gitignore
@@ -1,0 +1,5 @@
+.pio
+.vscode/.browse.c_cpp.db*
+.vscode/c_cpp_properties.json
+.vscode/launch.json
+.vscode/ipch

--- a/firmware/esp32/.vscode/extensions.json
+++ b/firmware/esp32/.vscode/extensions.json
@@ -1,0 +1,10 @@
+{
+    // See http://go.microsoft.com/fwlink/?LinkId=827846
+    // for the documentation about the extensions.json format
+    "recommendations": [
+        "platformio.platformio-ide"
+    ],
+    "unwantedRecommendations": [
+        "ms-vscode.cpptools-extension-pack"
+    ]
+}

--- a/firmware/esp32/cheatsheet.md
+++ b/firmware/esp32/cheatsheet.md
@@ -1,32 +1,32 @@
 Rebuild:
 ```sh
-pio run
+pio run
 ```
 
 Clean + full rebuild:
 ```sh
-pio run -t clean
-pio run
+pio run -t clean
+pio run
 ```
 
 Upload firmware to device:
 ```sh
-pio run -t upload
+pio run -t upload
 ```
 
 If auto-detect port fails, specify it:
 ```sh
-pio run -t upload --upload-port /dev/cu.usbserial-XXXX
+pio run -t upload --upload-port /dev/cu.usbserial-XXXX
 ```
 
 Optional serial monitor after flashing:
 ```sh
-pio device monitor -b 115200
+pio device monitor -b 115200
 ```
 
 If you want a non-default board env, add -e <env_name>, for example:
 ```sh
-pio run -e nodemcu_32s_wireless -t upload
+pio run -e nodemcu_32s_wireless -t upload
 ```
 
 check currently detected serial devices

--- a/firmware/esp32/cheatsheet.md
+++ b/firmware/esp32/cheatsheet.md
@@ -1,0 +1,35 @@
+Rebuild:
+```sh
+pio run
+```
+
+Clean + full rebuild:
+```sh
+pio run -t clean
+pio run
+```
+
+Upload firmware to device:
+```sh
+pio run -t upload
+```
+
+If auto-detect port fails, specify it:
+```sh
+pio run -t upload --upload-port /dev/cu.usbserial-XXXX
+```
+
+Optional serial monitor after flashing:
+```sh
+pio device monitor -b 115200
+```
+
+If you want a non-default board env, add -e <env_name>, for example:
+```sh
+pio run -e nodemcu_32s_wireless -t upload
+```
+
+check currently detected serial devices
+```sh
+pio device list
+```

--- a/firmware/esp32/platformio.ini
+++ b/firmware/esp32/platformio.ini
@@ -34,5 +34,8 @@ board = esp32-s3-devkitc-1
 build_flags =
   -DARDUINO_USB_MODE=1
   -DARDUINO_USB_CDC_ON_BOOT=1
+  -DCONFIG_BT_ACL_CONNECTIONS=3
+  -DCONFIG_BT_SSP_ENABLED=true
+  -DCONFIG_BT_BLE_50_FEATURES_SUPPORTED=false
 
 # Optional alternate hardware path for a future USB-HID implementation.

--- a/firmware/esp32/src/classic_bt_controller_transport.cpp
+++ b/firmware/esp32/src/classic_bt_controller_transport.cpp
@@ -379,6 +379,7 @@ void ClassicBtControllerTransport::clearConnectionState() {
   lastSendReportStatus_ = -1;
   lastSendReportReason_ = 0;
   lastSendReportId_ = 0;
+  sendFailureCount_ = 0;
   sendReportFailureCount_ = 0;
   lastDropReason_ = "none";
 }
@@ -557,6 +558,8 @@ void ClassicBtControllerTransport::ensureSendTask() {
 
 void ClassicBtControllerTransport::sendTaskTrampoline(void *param) {
   auto *transport = static_cast<ClassicBtControllerTransport *>(param);
+  // Initial delay to allow connection to stabilize
+  vTaskDelay(pdMS_TO_TICKS(500));
   while (true) {
     transport->sendCurrentInputReport(false);
     vTaskDelay(pdMS_TO_TICKS((transport->connected_ || transport->paired_) ? 15 : 100));
@@ -711,7 +714,10 @@ bool ClassicBtControllerTransport::sendCurrentInputReport(bool logFailure) {
     lastSendReportStatus_ = static_cast<int>(err);
     lastSendReportReason_ = 0;
     lastSendReportId_ = 0x30;
-    readyForReports_ = false;
+    sendFailureCount_++;
+    if (sendFailureCount_ > 5) {
+      readyForReports_ = false;
+    }
     if (logFailure) {
       Serial.printf(
           "WARN bt send_report failed err=%s connected=%s fail_count=%lu\n",
@@ -722,6 +728,7 @@ bool ClassicBtControllerTransport::sendCurrentInputReport(bool logFailure) {
     return false;
   }
 
+  sendFailureCount_ = 0;
   timer_ = static_cast<uint8_t>(timer_ + 1);
   return true;
 }
@@ -962,7 +969,6 @@ void ClassicBtControllerTransport::handleHidEvent(int event, void *rawParam) {
         hasPeerAddress_ = true;
         esp_bt_gap_set_scan_mode(ESP_BT_NON_CONNECTABLE, ESP_BT_NON_DISCOVERABLE);
         ensureSendTask();
-        sendCurrentInputReport(false);
       }
       Serial.printf(
           "INFO bt hid event=open status=%d conn=%d peer=%s\n",

--- a/firmware/esp32/src/classic_bt_controller_transport.cpp
+++ b/firmware/esp32/src/classic_bt_controller_transport.cpp
@@ -969,6 +969,7 @@ void ClassicBtControllerTransport::handleHidEvent(int event, void *rawParam) {
         hasPeerAddress_ = true;
         esp_bt_gap_set_scan_mode(ESP_BT_NON_CONNECTABLE, ESP_BT_NON_DISCOVERABLE);
         ensureSendTask();
+        sendCurrentInputReport(false);
       }
       Serial.printf(
           "INFO bt hid event=open status=%d conn=%d peer=%s\n",

--- a/firmware/esp32/src/classic_bt_controller_transport.cpp
+++ b/firmware/esp32/src/classic_bt_controller_transport.cpp
@@ -987,19 +987,25 @@ void ClassicBtControllerTransport::handleHidEvent(int event, void *rawParam) {
           param->close.conn_status);
       break;
     case ESP_HIDD_SEND_REPORT_EVT:
-      if (param->send_report.status != ESP_HIDD_SUCCESS) {
-        sendReportFailureCount_ += 1;
-      }
       lastSendReportStatus_ = param->send_report.status;
       lastSendReportReason_ = param->send_report.reason;
       lastSendReportId_ = param->send_report.report_id;
-      readyForReports_ = param->send_report.status == ESP_HIDD_SUCCESS && connected_;
+      
       if (param->send_report.status != ESP_HIDD_SUCCESS) {
+        sendReportFailureCount_ += 1;
+        sendFailureCount_++;
+        if (sendFailureCount_ > 5) {
+          readyForReports_ = false;
+        }
         Serial.printf(
-            "WARN bt hid event=send-report status=%d reason=%u report=%u\n",
+            "WARN bt hid event=send-report status=%d reason=%u report=%u fail_count=%u\n",
             param->send_report.status,
             param->send_report.reason,
-            param->send_report.report_id);
+            param->send_report.report_id,
+            sendFailureCount_);
+      } else {
+        sendFailureCount_ = 0;
+        readyForReports_ = connected_;
       }
       break;
     case ESP_HIDD_GET_REPORT_EVT:

--- a/firmware/esp32/src/classic_bt_controller_transport.h
+++ b/firmware/esp32/src/classic_bt_controller_transport.h
@@ -50,6 +50,7 @@ class ClassicBtControllerTransport : public ControllerTransport {
   bool pairingComplete_ = false;
   bool paired_ = false;
   uint8_t timer_ = 0;
+  int sendFailureCount_ = 0;
   const char *initStep_ = "idle";
   const char *initError_ = "none";
   uint8_t buttonsRight_ = 0;

--- a/firmware/esp32/src/main.cpp
+++ b/firmware/esp32/src/main.cpp
@@ -194,7 +194,13 @@ void loop() {
   SequencedFrame frame;
 
   if (!parseSequencedFrame(line, frame)) {
-    Serial.println("ERR protocol frame required");
+    String error;
+    const bool ok = executeCommand(line, controller, error);
+
+    if (!ok) {
+      Serial.println("ERR raw " + (error.length() > 0 ? error : "unknown error"));
+    }
+
     return;
   }
 


### PR DESCRIPTION
- Support both sequenced (SEQ) and raw command input for debugging purpose
- Add explicit error messages distinguishing sequenced vs raw failures
- Update PlatformIO config and add development cheatsheet
- Improve Bluetooth transport reliability
- Add consecutive send failure tracking (sendFailureCount_) with circuit breaker to halt HID reports after 5 consecutive failures