### PR TITLE
Add persistent serial session management

### DIFF
--- a/apps/desktop/src/serial/sender.ts
+++ b/apps/desktop/src/serial/sender.ts
@@ -1,5 +1,3 @@
-import { once } from "node:events";
-
 import { ReadlineParser } from "@serialport/parser-readline";
 import { SerialPort } from "serialport";
 
@@ -32,14 +30,6 @@ export interface SerialSessionSnapshot {
   busy: boolean;
   idleTimeoutMs: number;
   lastUsedAt: number | null;
-}
-
-async function waitForOpen(port: SerialPort): Promise<void> {
-  if (port.isOpen) {
-    return;
-  }
-
-  await once(port, "open");
 }
 
 function isRecognizedDeviceLine(line: string): boolean {
@@ -250,6 +240,24 @@ function writeLine(port: SerialPort, line: string): Promise<void> {
   });
 }
 
+function openPort(port: SerialPort): Promise<void> {
+  return new Promise((resolve, reject) => {
+    if (port.isOpen) {
+      resolve();
+      return;
+    }
+
+    port.open((error) => {
+      if (error) {
+        reject(error);
+        return;
+      }
+
+      resolve();
+    });
+  });
+}
+
 function closePort(port: SerialPort): Promise<void> {
   return new Promise((resolve, reject) => {
     if (!port.isOpen) {
@@ -278,6 +286,10 @@ export class SerialCommandSession {
   private sequence = 1;
   private interruptAckWait: (() => void) | null = null;
   private lastUsedAtValue: number | null = null;
+  private openingPromise: Promise<void> | null = null;
+  private closingPromise: Promise<void> | null = null;
+  private portErrorHandler: ((error: Error) => void) | null = null;
+  private portCloseHandler: (() => void) | null = null;
 
   constructor(path: string, baudRate: number) {
     this.portPath = preferSerialPath(path);
@@ -297,14 +309,45 @@ export class SerialCommandSession {
       return;
     }
 
-    this.port = new SerialPort({
+    if (this.openingPromise) {
+      await this.openingPromise;
+      return;
+    }
+
+    const port = new SerialPort({
       path: this.portPath,
       baudRate: this.baudRate,
-      autoOpen: true,
+      autoOpen: false,
       hupcl: false,
     });
-    this.parser = this.port.pipe(new ReadlineParser({ delimiter: "\n" }));
-    await waitForOpen(this.port);
+    const parser = port.pipe(new ReadlineParser({ delimiter: "\n" }));
+    this.port = port;
+    this.parser = parser;
+    this.attachPortLifecycleHandlers(port);
+
+    const openingPromise = openPort(port);
+    this.openingPromise = openingPromise;
+
+    try {
+      await openingPromise;
+    } catch (error) {
+      if (this.port === port) {
+        this.port = null;
+        this.parser = null;
+      }
+
+      this.detachPortLifecycleHandlers(port);
+      throw error;
+    } finally {
+      if (this.openingPromise === openingPromise) {
+        this.openingPromise = null;
+      }
+    }
+
+    if (this.port !== port || !port.isOpen || !this.parser) {
+      throw new Error("Serial session is not open.");
+    }
+
     this.lastUsedAtValue = Date.now();
     onDeviceLine?.(`INFO serial_session=open port=${this.portPath} baud=${this.baudRate}`);
   }
@@ -313,14 +356,84 @@ export class SerialCommandSession {
     this.interruptAckWait?.();
     this.interruptAckWait = null;
 
-    if (!this.port) {
+    const port = this.port;
+
+    if (!port) {
       return;
     }
 
-    const port = this.port;
-    this.port = null;
-    this.parser = null;
-    await closePort(port);
+    if (this.closingPromise) {
+      await this.closingPromise;
+      return;
+    }
+
+    const openingPromise = this.openingPromise;
+    this.closingPromise = (async () => {
+      try {
+        try {
+          await openingPromise;
+        } catch {
+          // Opening failed, so there is no open descriptor left to close.
+        }
+
+        if (port.isOpen) {
+          await closePort(port);
+        }
+      } finally {
+        this.detachPortLifecycleHandlers(port);
+
+        if (this.port === port) {
+          this.port = null;
+          this.parser = null;
+        }
+
+        if (this.openingPromise === openingPromise) {
+          this.openingPromise = null;
+        }
+
+        this.closingPromise = null;
+      }
+    })();
+
+    await this.closingPromise;
+  }
+
+  private attachPortLifecycleHandlers(port: SerialPort): void {
+    this.portErrorHandler = () => {
+      // Persistent sessions can be idle when a USB device is unplugged. Keep
+      // those EventEmitter errors handled, then invalidate the session.
+      queueMicrotask(() => {
+        if (this.port === port) {
+          void this.close().catch(() => {
+            // The error event already tells us this descriptor is not healthy.
+          });
+        }
+      });
+    };
+    this.portCloseHandler = () => {
+      if (this.port === port) {
+        this.port = null;
+        this.parser = null;
+        this.openingPromise = null;
+      }
+
+      this.detachPortLifecycleHandlers(port);
+    };
+
+    port.on("error", this.portErrorHandler);
+    port.on("close", this.portCloseHandler);
+  }
+
+  private detachPortLifecycleHandlers(port: SerialPort): void {
+    if (this.portErrorHandler) {
+      port.off("error", this.portErrorHandler);
+      this.portErrorHandler = null;
+    }
+
+    if (this.portCloseHandler) {
+      port.off("close", this.portCloseHandler);
+      this.portCloseHandler = null;
+    }
   }
 
   async send(commands: string[], options: SerialCommandSendOptions): Promise<void> {

--- a/apps/desktop/src/serial/sender.ts
+++ b/apps/desktop/src/serial/sender.ts
@@ -13,6 +13,26 @@ import type { ProgressUpdate, SenderControls } from "../types.js";
 
 const ACK_LINE_PREFIXES = ["OK ", "ERR "] as const;
 const DEVICE_LINE_PREFIXES = ["INFO ", "WARN ", "BOOT ", "rst:"] as const;
+export const DEFAULT_SERIAL_SESSION_IDLE_TIMEOUT_MS = 15 * 60 * 1_000;
+
+interface SerialCommandSendOptions {
+  ackTimeoutMs: number;
+  retries: number;
+  onProgress?: (progress: ProgressUpdate) => void;
+  onDeviceLine?: (line: string) => void;
+  beforeCommand?: () => Promise<void>;
+  shouldStop?: () => boolean;
+  onInterruptReady?: (interrupt: (() => void) | null) => void;
+}
+
+export interface SerialSessionSnapshot {
+  connected: boolean;
+  portPath: string | null;
+  baudRate: number | null;
+  busy: boolean;
+  idleTimeoutMs: number;
+  lastUsedAt: number | null;
+}
 
 async function waitForOpen(port: SerialPort): Promise<void> {
   if (port.isOpen) {
@@ -230,10 +250,260 @@ function writeLine(port: SerialPort, line: string): Promise<void> {
   });
 }
 
+function closePort(port: SerialPort): Promise<void> {
+  return new Promise((resolve, reject) => {
+    if (!port.isOpen) {
+      resolve();
+      return;
+    }
+
+    port.close((error) => {
+      if (error) {
+        reject(error);
+        return;
+      }
+
+      resolve();
+    });
+  });
+}
+
+export class SerialCommandSession {
+  readonly portPath: string;
+  readonly baudRate: number;
+
+  private port: SerialPort | null = null;
+  private parser: ReadlineParser | null = null;
+  private sessionId = createSessionId();
+  private sequence = 1;
+  private interruptAckWait: (() => void) | null = null;
+  private lastUsedAtValue: number | null = null;
+
+  constructor(path: string, baudRate: number) {
+    this.portPath = preferSerialPath(path);
+    this.baudRate = baudRate;
+  }
+
+  get isConnected(): boolean {
+    return this.port?.isOpen === true;
+  }
+
+  get lastUsedAt(): number | null {
+    return this.lastUsedAtValue;
+  }
+
+  async open(onDeviceLine?: (line: string) => void): Promise<void> {
+    if (this.port?.isOpen && this.parser) {
+      return;
+    }
+
+    this.port = new SerialPort({
+      path: this.portPath,
+      baudRate: this.baudRate,
+      autoOpen: true,
+      hupcl: false,
+    });
+    this.parser = this.port.pipe(new ReadlineParser({ delimiter: "\n" }));
+    await waitForOpen(this.port);
+    this.lastUsedAtValue = Date.now();
+    onDeviceLine?.(`INFO serial_session=open port=${this.portPath} baud=${this.baudRate}`);
+  }
+
+  async close(): Promise<void> {
+    this.interruptAckWait?.();
+    this.interruptAckWait = null;
+
+    if (!this.port) {
+      return;
+    }
+
+    const port = this.port;
+    this.port = null;
+    this.parser = null;
+    await closePort(port);
+  }
+
+  async send(commands: string[], options: SerialCommandSendOptions): Promise<void> {
+    await this.open(options.onDeviceLine);
+
+    if (!this.port || !this.parser) {
+      throw new Error("Serial session is not open.");
+    }
+
+    for (const [index, command] of commands.entries()) {
+      await options.beforeCommand?.();
+
+      if (options.shouldStop?.()) {
+        break;
+      }
+
+      let attempt = 0;
+      let sent = false;
+      const commandSequence = this.sequence;
+      const framedCommand = formatSequencedCommand(this.sessionId, commandSequence, command);
+
+      while (!sent) {
+        try {
+          await writeLine(this.port, framedCommand);
+          await waitForAck(
+            this.parser,
+            this.port,
+            getAckTimeoutForCommand(command, options.ackTimeoutMs),
+            {
+              sessionId: this.sessionId,
+              sequence: commandSequence,
+            },
+            {
+              ...(options.onDeviceLine ? { onDeviceLine: options.onDeviceLine } : {}),
+              onInterruptReady: (interrupt) => {
+                this.interruptAckWait = interrupt;
+                options.onInterruptReady?.(interrupt);
+              },
+            },
+          );
+          sent = true;
+        } catch (error) {
+          if (options.shouldStop?.()) {
+            throw new Error("Execution stopped.");
+          }
+
+          if (attempt >= options.retries) {
+            throw error;
+          }
+
+          const message = error instanceof Error ? error.message : String(error);
+          options.onDeviceLine?.(
+            `WARN retry command=${index + 1} attempt=${attempt + 1} reason=${message}`,
+          );
+          attempt += 1;
+        }
+      }
+
+      options.onProgress?.({
+        index: index + 1,
+        total: commands.length,
+        command,
+      });
+      this.sequence += 1;
+      this.lastUsedAtValue = Date.now();
+    }
+  }
+}
+
+export class SerialSessionManager {
+  private session: SerialCommandSession | null = null;
+  private queue: Promise<void> = Promise.resolve();
+  private pendingOperations = 0;
+  private idleTimer: NodeJS.Timeout | null = null;
+
+  constructor(private readonly idleTimeoutMs = DEFAULT_SERIAL_SESSION_IDLE_TIMEOUT_MS) {}
+
+  snapshot(): SerialSessionSnapshot {
+    return {
+      connected: this.session?.isConnected === true,
+      portPath: this.session?.portPath ?? null,
+      baudRate: this.session?.baudRate ?? null,
+      busy: this.pendingOperations > 0,
+      idleTimeoutMs: this.idleTimeoutMs,
+      lastUsedAt: this.session?.lastUsedAt ?? null,
+    };
+  }
+
+  async send(
+    commands: string[],
+    options: {
+      path: string;
+      baudRate: number;
+    } & SerialCommandSendOptions,
+  ): Promise<void> {
+    this.pendingOperations += 1;
+    this.clearIdleTimer();
+
+    const queuedSend = this.queue.then(async () => {
+      try {
+        const session = await this.getSession(options.path, options.baudRate, options.onDeviceLine);
+        await session.send(commands, options);
+      } catch (error) {
+        await this.closeCurrentSession();
+        throw error;
+      }
+    });
+
+    this.queue = queuedSend.catch(() => undefined);
+
+    try {
+      await queuedSend;
+    } finally {
+      this.pendingOperations -= 1;
+      if (this.pendingOperations === 0) {
+        this.scheduleIdleClose();
+      }
+    }
+  }
+
+  async disconnect(options: { force?: boolean } = {}): Promise<SerialSessionSnapshot> {
+    if (this.pendingOperations > 0 && options.force !== true) {
+      throw new Error("Serial session is busy.");
+    }
+
+    this.clearIdleTimer();
+    await this.closeCurrentSession();
+    return this.snapshot();
+  }
+
+  private async getSession(
+    path: string,
+    baudRate: number,
+    onDeviceLine?: (line: string) => void,
+  ): Promise<SerialCommandSession> {
+    const preferredPath = preferSerialPath(path);
+
+    if (
+      !this.session ||
+      !this.session.isConnected ||
+      this.session.portPath !== preferredPath ||
+      this.session.baudRate !== baudRate
+    ) {
+      await this.closeCurrentSession();
+      this.session = new SerialCommandSession(preferredPath, baudRate);
+      onDeviceLine?.(`INFO serial_session=create port=${preferredPath} baud=${baudRate}`);
+    } else {
+      onDeviceLine?.(`INFO serial_session=reuse port=${preferredPath} baud=${baudRate}`);
+    }
+
+    return this.session;
+  }
+
+  private async closeCurrentSession(): Promise<void> {
+    const session = this.session;
+    this.session = null;
+    await session?.close();
+  }
+
+  private scheduleIdleClose(): void {
+    if (!this.session?.isConnected) {
+      return;
+    }
+
+    this.idleTimer = setTimeout(() => {
+      void this.disconnect({ force: true });
+    }, this.idleTimeoutMs);
+  }
+
+  private clearIdleTimer(): void {
+    if (!this.idleTimer) {
+      return;
+    }
+
+    clearTimeout(this.idleTimer);
+    this.idleTimer = null;
+  }
+}
+
 export class SerialAckSender implements SenderControls {
   private paused = false;
   private stopped = false;
-  private activePort: SerialPort | null = null;
+  private activeSession: SerialCommandSession | null = null;
   private interruptAckWait: (() => void) | null = null;
 
   pause(): void {
@@ -249,13 +519,11 @@ export class SerialAckSender implements SenderControls {
     this.interruptAckWait?.();
     this.interruptAckWait = null;
 
-    if (this.activePort?.isOpen) {
-      this.activePort.close(() => {
-        // Intentionally ignored: closing the port here is only used to break
-        // a blocking ACK wait so the execution can transition out of
-        // `stopping` immediately.
-      });
-    }
+    void this.activeSession?.close().catch(() => {
+      // Intentionally ignored: closing the session here is only used to break
+      // a blocking ACK wait so the execution can transition out of
+      // `stopping` immediately.
+    });
   }
 
   private async waitWhilePaused(): Promise<void> {
@@ -278,96 +546,25 @@ export class SerialAckSender implements SenderControls {
     this.paused = false;
     this.stopped = false;
 
-    const preferredPath = preferSerialPath(options.path);
-    const port = new SerialPort({
-      path: preferredPath,
-      baudRate: options.baudRate,
-      autoOpen: true,
-    });
-    this.activePort = port;
-
-    const parser = port.pipe(new ReadlineParser({ delimiter: "\n" }));
-    const sessionId = createSessionId();
-    let sequence = 1;
+    const session = new SerialCommandSession(options.path, options.baudRate);
+    this.activeSession = session;
 
     try {
-      await waitForOpen(port);
-
-      for (const [index, command] of commands.entries()) {
-        await this.waitWhilePaused();
-
-        if (this.stopped) {
-          break;
-        }
-
-        let attempt = 0;
-        let sent = false;
-        const commandSequence = sequence;
-        const framedCommand = formatSequencedCommand(sessionId, commandSequence, command);
-
-        while (!sent) {
-          try {
-            await writeLine(port, framedCommand);
-            await waitForAck(
-              parser,
-              port,
-              getAckTimeoutForCommand(command, options.ackTimeoutMs),
-              {
-                sessionId,
-                sequence: commandSequence,
-              },
-              {
-                ...(options.onDeviceLine ? { onDeviceLine: options.onDeviceLine } : {}),
-                onInterruptReady: (interrupt) => {
-                  this.interruptAckWait = interrupt;
-                },
-              },
-            );
-            sent = true;
-          } catch (error) {
-            if (this.stopped) {
-              throw new Error("Execution stopped.");
-            }
-
-            if (attempt >= options.retries) {
-              throw error;
-            }
-
-            const message = error instanceof Error ? error.message : String(error);
-            options.onDeviceLine?.(
-              `WARN retry command=${index + 1} attempt=${attempt + 1} reason=${message}`,
-            );
-            attempt += 1;
-          }
-        }
-
-        options.onProgress?.({
-          index: index + 1,
-          total: commands.length,
-          command,
-        });
-        sequence += 1;
-      }
-
-      if (this.stopped && port.isOpen) {
-        await writeLine(port, formatSequencedCommand(sessionId, sequence, "E"));
-      }
+      await session.send(commands, {
+        ackTimeoutMs: options.ackTimeoutMs,
+        retries: options.retries,
+        ...(options.onProgress ? { onProgress: options.onProgress } : {}),
+        ...(options.onDeviceLine ? { onDeviceLine: options.onDeviceLine } : {}),
+        beforeCommand: () => this.waitWhilePaused(),
+        shouldStop: () => this.stopped,
+        onInterruptReady: (interrupt) => {
+          this.interruptAckWait = interrupt;
+        },
+      });
     } finally {
       this.interruptAckWait = null;
-      this.activePort = null;
-
-      if (port.isOpen) {
-        await new Promise<void>((resolve, reject) => {
-          port.close((error) => {
-            if (error) {
-              reject(error);
-              return;
-            }
-
-            resolve();
-          });
-        });
-      }
+      this.activeSession = null;
+      await session.close();
     }
   }
 }

--- a/apps/desktop/src/serial/sender.ts
+++ b/apps/desktop/src/serial/sender.ts
@@ -67,6 +67,19 @@ function sanitizeDeviceLine(rawLine: string | Buffer): string | null {
   return isRecognizedDeviceLine(candidate) ? candidate : null;
 }
 
+function getEmbeddedDeviceLine(line: string): string | null {
+  const candidateIndexes = DEVICE_LINE_PREFIXES.map((prefix) => line.indexOf(prefix)).filter(
+    (index) => index > 0,
+  );
+
+  if (candidateIndexes.length === 0) {
+    return null;
+  }
+
+  const candidate = line.slice(Math.min(...candidateIndexes)).trim();
+  return DEVICE_LINE_PREFIXES.some((prefix) => candidate.startsWith(prefix)) ? candidate : null;
+}
+
 function waitForAck(
   parser: ReadlineParser,
   port: SerialPort,
@@ -129,6 +142,14 @@ function waitForAck(
       }
 
       if (line === "OK" || line === "ERR" || line.startsWith("OK ") || line.startsWith("ERR ")) {
+        const embeddedDeviceLine = getEmbeddedDeviceLine(line);
+
+        if (embeddedDeviceLine) {
+          options?.onDeviceLine?.(`WARN ignored malformed serial line=${line}`);
+          options?.onDeviceLine?.(embeddedDeviceLine);
+          return;
+        }
+
         finish(() =>
           reject(
             new Error(
@@ -258,6 +279,24 @@ function openPort(port: SerialPort): Promise<void> {
   });
 }
 
+function flushPort(port: SerialPort): Promise<void> {
+  return new Promise((resolve, reject) => {
+    if (!port.isOpen) {
+      resolve();
+      return;
+    }
+
+    port.flush((error) => {
+      if (error) {
+        reject(error);
+        return;
+      }
+
+      resolve();
+    });
+  });
+}
+
 function closePort(port: SerialPort): Promise<void> {
   return new Promise((resolve, reject) => {
     if (!port.isOpen) {
@@ -320,12 +359,31 @@ export class SerialCommandSession {
       autoOpen: false,
       hupcl: false,
     });
-    const parser = port.pipe(new ReadlineParser({ delimiter: "\n" }));
     this.port = port;
-    this.parser = parser;
     this.attachPortLifecycleHandlers(port);
 
-    const openingPromise = openPort(port);
+    const openingPromise = (async () => {
+      await openPort(port);
+
+      if (this.port !== port || !port.isOpen) {
+        throw new Error("Serial session is not open.");
+      }
+
+      try {
+        await flushPort(port);
+      } catch (error) {
+        const message = error instanceof Error ? error.message : String(error);
+        onDeviceLine?.(`WARN serial_flush_failed reason=${message}`);
+      }
+
+      if (this.port !== port || !port.isOpen) {
+        throw new Error("Serial session is not open.");
+      }
+
+      this.parser = port.pipe(new ReadlineParser({ delimiter: "\n" }));
+      this.lastUsedAtValue = Date.now();
+      onDeviceLine?.(`INFO serial_session=open port=${this.portPath} baud=${this.baudRate}`);
+    })();
     this.openingPromise = openingPromise;
 
     try {
@@ -343,13 +401,6 @@ export class SerialCommandSession {
         this.openingPromise = null;
       }
     }
-
-    if (this.port !== port || !port.isOpen || !this.parser) {
-      throw new Error("Serial session is not open.");
-    }
-
-    this.lastUsedAtValue = Date.now();
-    onDeviceLine?.(`INFO serial_session=open port=${this.portPath} baud=${this.baudRate}`);
   }
 
   async close(): Promise<void> {

--- a/apps/desktop/src/web/server.ts
+++ b/apps/desktop/src/web/server.ts
@@ -11,7 +11,10 @@ import { applyCliOptions, type CliOptions } from "../cli/args.js";
 import { loadProfile } from "../config/loadProfile.js";
 import { OFFICIAL_COLOR_GRID } from "../config/officialPalette.js";
 import { listPortInfos, preferSerialPath } from "../serial/listPorts.js";
-import { SerialAckSender } from "../serial/sender.js";
+import {
+  SerialSessionManager,
+  type SerialSessionSnapshot,
+} from "../serial/sender.js";
 import { SimulatedAckSender } from "../simulator/sender.js";
 import type { SenderControls } from "../types.js";
 
@@ -22,6 +25,7 @@ const staticRoot = path.join(__dirname, "static");
 const firmwareRoot = path.join(repoRoot, "firmware", "esp32");
 const host = "127.0.0.1";
 const port = 4307;
+const serialSessionManager = new SerialSessionManager();
 
 const FIRMWARE_ENVIRONMENTS = [
   {
@@ -89,6 +93,66 @@ let managedExecution: ManagedExecution = createEmptyExecution();
 
 function resetManagedExecutionState(): void {
   managedExecution = createEmptyExecution();
+}
+
+class ManagedSerialSessionSender implements SenderControls {
+  private paused = false;
+  private stopped = false;
+  private interruptAckWait: (() => void) | null = null;
+
+  constructor(private readonly sessionManager: SerialSessionManager) {}
+
+  pause(): void {
+    this.paused = true;
+  }
+
+  resume(): void {
+    this.paused = false;
+  }
+
+  stop(): void {
+    this.stopped = true;
+    this.interruptAckWait?.();
+    this.interruptAckWait = null;
+    void this.sessionManager.disconnect({ force: true }).catch(() => {
+      // Stop uses disconnect only to interrupt a blocking ACK wait.
+    });
+  }
+
+  async send(
+    commands: string[],
+    options: {
+      path: string;
+      baudRate: number;
+      ackTimeoutMs: number;
+      retries: number;
+      onProgress?: (progress: { index: number; total: number; command: string }) => void;
+      onDeviceLine?: (line: string) => void;
+    },
+  ): Promise<void> {
+    this.paused = false;
+    this.stopped = false;
+
+    await this.sessionManager.send(commands, {
+      path: options.path,
+      baudRate: options.baudRate,
+      ackTimeoutMs: options.ackTimeoutMs,
+      retries: options.retries,
+      ...(options.onProgress ? { onProgress: options.onProgress } : {}),
+      ...(options.onDeviceLine ? { onDeviceLine: options.onDeviceLine } : {}),
+      beforeCommand: () => this.waitWhilePaused(),
+      shouldStop: () => this.stopped,
+      onInterruptReady: (interrupt) => {
+        this.interruptAckWait = interrupt;
+      },
+    });
+  }
+
+  private async waitWhilePaused(): Promise<void> {
+    while (this.paused && !this.stopped) {
+      await new Promise((resolve) => setTimeout(resolve, 50));
+    }
+  }
 }
 
 function json(
@@ -431,6 +495,7 @@ async function executeCommands(body: {
   target: "simulate" | "serial";
   totalCommands: number;
   lines: string[];
+  session: SerialSessionSnapshot;
 }> {
   if (!Array.isArray(body.commands) || body.commands.length === 0) {
     throw new Error("Missing commands.");
@@ -446,11 +511,13 @@ async function executeCommands(body: {
       throw new Error("Missing portPath.");
     }
 
-    const sender = new SerialAckSender();
+    if (isManagedExecutionActive(managedExecution.status)) {
+      throw new Error("Drawing execution is already running.");
+    }
 
     lines.push(`INFO port=${body.portPath} baud=${body.baudRate ?? 115200}`);
 
-    await sender.send(body.commands, {
+    await serialSessionManager.send(body.commands, {
       path: body.portPath,
       baudRate: body.baudRate ?? 115200,
       ackTimeoutMs,
@@ -480,6 +547,7 @@ async function executeCommands(body: {
     target,
     totalCommands: body.commands.length,
     lines,
+    session: serialSessionManager.snapshot(),
   };
 }
 
@@ -510,7 +578,7 @@ async function runManagedExecution(
         throw new Error("Missing portPath.");
       }
 
-      const sender = execution.sender as SerialAckSender;
+      const sender = execution.sender as ManagedSerialSessionSender;
       appendManagedExecutionLine(
         execution,
         `INFO port=${body.portPath} baud=${body.baudRate ?? 115200}`,
@@ -601,7 +669,7 @@ async function startManagedExecution(body: {
   }
 
   const sender: SenderControls =
-    target === "serial" ? new SerialAckSender() : new SimulatedAckSender();
+    target === "serial" ? new ManagedSerialSessionSender(serialSessionManager) : new SimulatedAckSender();
 
   const execution: ManagedExecution = {
     id: executionCounter += 1,
@@ -694,6 +762,7 @@ async function handleFirmwareFlash(
 
     const environment = getFirmwareEnvironment(body.environmentId);
     const portPath = preferSerialPath(body.portPath);
+    const session = await serialSessionManager.disconnect();
     const result = await runPlatformIo([
       "run",
       "-e",
@@ -710,10 +779,11 @@ async function handleFirmwareFlash(
       portPath,
       platformIoPath: result.platformIoPath,
       output: result.output,
+      session,
     });
   } catch (error) {
     const message = error instanceof Error ? error.message : String(error);
-    json(response, 400, { error: message });
+    json(response, 400, { error: message, session: serialSessionManager.snapshot() });
   }
 }
 
@@ -733,7 +803,7 @@ async function handleExecute(request: IncomingMessage, response: ServerResponse)
     json(response, 200, await executeCommands(body));
   } catch (error) {
     const message = error instanceof Error ? error.message : String(error);
-    json(response, 400, { error: message });
+    json(response, 400, { error: message, session: serialSessionManager.snapshot() });
   }
 }
 
@@ -756,10 +826,11 @@ async function handleExecutionStart(
     json(response, 200, {
       success: true,
       execution: await startManagedExecution(body),
+      session: serialSessionManager.snapshot(),
     });
   } catch (error) {
     const message = error instanceof Error ? error.message : String(error);
-    json(response, 400, { error: message });
+    json(response, 400, { error: message, session: serialSessionManager.snapshot() });
   }
 }
 
@@ -767,7 +838,28 @@ async function handleExecutionStatus(response: ServerResponse): Promise<void> {
   json(response, 200, {
     success: true,
     execution: snapshotManagedExecution(),
+    session: serialSessionManager.snapshot(),
   });
+}
+
+async function handleSerialSessionStatus(response: ServerResponse): Promise<void> {
+  json(response, 200, { ...serialSessionManager.snapshot() });
+}
+
+async function handleSerialSessionDisconnect(response: ServerResponse): Promise<void> {
+  try {
+    if (isManagedExecutionActive(managedExecution.status)) {
+      throw new Error("Drawing execution is active.");
+    }
+
+    json(response, 200, {
+      success: true,
+      session: await serialSessionManager.disconnect(),
+    });
+  } catch (error) {
+    const message = error instanceof Error ? error.message : String(error);
+    json(response, 400, { error: message, session: serialSessionManager.snapshot() });
+  }
 }
 
 function updateManagedExecutionState(
@@ -793,10 +885,11 @@ async function handleExecutionPause(response: ServerResponse): Promise<void> {
     json(response, 200, {
       success: true,
       execution: updateManagedExecutionState("paused", "INFO execution paused"),
+      session: serialSessionManager.snapshot(),
     });
   } catch (error) {
     const message = error instanceof Error ? error.message : String(error);
-    json(response, 400, { error: message });
+    json(response, 400, { error: message, session: serialSessionManager.snapshot() });
   }
 }
 
@@ -810,10 +903,11 @@ async function handleExecutionResume(response: ServerResponse): Promise<void> {
     json(response, 200, {
       success: true,
       execution: updateManagedExecutionState("running", "INFO execution resumed"),
+      session: serialSessionManager.snapshot(),
     });
   } catch (error) {
     const message = error instanceof Error ? error.message : String(error);
-    json(response, 400, { error: message });
+    json(response, 400, { error: message, session: serialSessionManager.snapshot() });
   }
 }
 
@@ -827,10 +921,11 @@ async function handleExecutionStop(response: ServerResponse): Promise<void> {
     json(response, 200, {
       success: true,
       execution: updateManagedExecutionState("stopping", "INFO execution stop requested"),
+      session: serialSessionManager.snapshot(),
     });
   } catch (error) {
     const message = error instanceof Error ? error.message : String(error);
-    json(response, 400, { error: message });
+    json(response, 400, { error: message, session: serialSessionManager.snapshot() });
   }
 }
 
@@ -844,10 +939,11 @@ async function handleExecutionReset(response: ServerResponse): Promise<void> {
     json(response, 200, {
       success: true,
       execution: snapshotManagedExecution(),
+      session: serialSessionManager.snapshot(),
     });
   } catch (error) {
     const message = error instanceof Error ? error.message : String(error);
-    json(response, 400, { error: message });
+    json(response, 400, { error: message, session: serialSessionManager.snapshot() });
   }
 }
 
@@ -869,7 +965,7 @@ async function handleSimulate(request: IncomingMessage, response: ServerResponse
     );
   } catch (error) {
     const message = error instanceof Error ? error.message : String(error);
-    json(response, 400, { error: message });
+    json(response, 400, { error: message, session: serialSessionManager.snapshot() });
   }
 }
 
@@ -924,6 +1020,16 @@ const server = createServer(async (request, response) => {
 
     if (request.method === "POST" && url.pathname === "/api/execute") {
       await handleExecute(request, response);
+      return;
+    }
+
+    if (request.method === "GET" && url.pathname === "/api/serial-session/status") {
+      await handleSerialSessionStatus(response);
+      return;
+    }
+
+    if (request.method === "POST" && url.pathname === "/api/serial-session/disconnect") {
+      await handleSerialSessionDisconnect(response);
       return;
     }
 

--- a/apps/desktop/src/web/static/app.js
+++ b/apps/desktop/src/web/static/app.js
@@ -4,6 +4,14 @@ const state = {
   commands: [],
   ports: [],
   selectedPortPath: "",
+  serialSession: {
+    connected: false,
+    portPath: null,
+    baudRate: null,
+    busy: false,
+    idleTimeoutMs: 15 * 60 * 1000,
+    lastUsedAt: null,
+  },
   firmwareEnvironments: [],
   firmwareTooling: {
     available: false,
@@ -164,6 +172,8 @@ const els = {
   controllerRefreshButton: document.getElementById("controller-refresh-button"),
   controllerInfoButton: document.getElementById("controller-info-button"),
   controllerResetButton: document.getElementById("controller-reset-button"),
+  controllerDisconnectButton: document.getElementById("controller-disconnect-button"),
+  controllerSerialSessionStatus: document.getElementById("controller-serial-session-status"),
   controllerActionButtons: [...document.querySelectorAll("[data-controller-action]")],
   controllerCustomCommands: document.getElementById("controller-custom-commands"),
   controllerSendCustomButton: document.getElementById("controller-send-custom-button"),
@@ -666,9 +676,11 @@ async function executeStudioCommands({ logPrefix }) {
     const payload = await response.json();
 
     if (!response.ok) {
+      applySerialSessionSnapshot(payload.session);
       throw new Error(payload.error ?? "执行失败");
     }
 
+    applySerialSessionSnapshot(payload.session);
     applyStudioExecutionSnapshot(payload.execution);
     startStudioExecutionPolling();
     return true;
@@ -732,6 +744,7 @@ els.firmwareFlashButton.addEventListener("click", async () => {
     els.firmwareLogOutput,
     `开始刷入固件：${state.firmware.environmentId} -> ${state.selectedPortPath}`,
   );
+  appendLog(els.firmwareLogOutput, "刷入前会自动释放串口会话，避免端口占用。");
 
   try {
     const response = await fetch("/api/firmware/flash", {
@@ -745,6 +758,7 @@ els.firmwareFlashButton.addEventListener("click", async () => {
     const payload = await response.json();
 
     if (!response.ok) {
+      applySerialSessionSnapshot(payload.session);
       throw new Error(payload.error ?? "刷入固件失败");
     }
 
@@ -755,6 +769,8 @@ els.firmwareFlashButton.addEventListener("click", async () => {
       environmentLabel: payload.environment.label,
       portPath: state.selectedPortPath,
     });
+    applySerialSessionSnapshot(payload.session);
+    appendLog(els.firmwareLogOutput, "刷入前已释放串口会话。");
     appendLog(els.firmwareLogOutput, `刷入完成：${payload.environment.label}`);
     appendLog(els.firmwareLogOutput, payload.output.trim());
   } catch (error) {
@@ -781,6 +797,30 @@ els.controllerInfoButton.addEventListener("click", async () => {
 
 els.controllerResetButton.addEventListener("click", async () => {
   await runControllerCommands(["BT RESET"], "重置手柄蓝牙");
+});
+
+els.controllerDisconnectButton.addEventListener("click", async () => {
+  setControllerBusy(true);
+
+  try {
+    const response = await fetch("/api/serial-session/disconnect", {
+      method: "POST",
+      headers: { "content-type": "application/json" },
+    });
+    const payload = await response.json();
+
+    if (!response.ok) {
+      applySerialSessionSnapshot(payload.session);
+      throw new Error(payload.error ?? "断开串口失败");
+    }
+
+    applySerialSessionSnapshot(payload.session);
+    appendLog(els.controllerLogOutput, "串口连接已断开。");
+  } catch (error) {
+    appendLog(els.controllerLogOutput, `断开串口失败：${getErrorMessage(error)}`);
+  } finally {
+    setControllerBusy(false);
+  }
 });
 
 els.controllerActionButtons.forEach((button) => {
@@ -952,10 +992,12 @@ async function pollStudioExecutionStatus() {
     const payload = await response.json();
 
     if (!response.ok) {
+      applySerialSessionSnapshot(payload.session);
       throw new Error(payload.error ?? "读取绘制状态失败");
     }
 
     applyStudioExecutionSnapshot(payload.execution);
+    applySerialSessionSnapshot(payload.session);
   } catch (error) {
     stopStudioExecutionPolling();
     appendLog(els.studioLogOutput, `读取绘制状态失败：${getErrorMessage(error)}`);
@@ -991,11 +1033,13 @@ async function sendStudioExecutionControl(action, label) {
     const payload = await response.json();
 
     if (!response.ok) {
+      applySerialSessionSnapshot(payload.session);
       throw new Error(payload.error ?? `${label}失败`);
     }
 
     appendLog(els.studioLogOutput, `${label}请求已发送。`);
     applyStudioExecutionSnapshot(payload.execution);
+    applySerialSessionSnapshot(payload.session);
   } catch (error) {
     appendLog(els.studioLogOutput, `${label}失败：${getErrorMessage(error)}`);
   }
@@ -1059,6 +1103,68 @@ function boolLabel(value, labels) {
   }
 
   return "未知";
+}
+
+function applySerialSessionSnapshot(snapshot) {
+  if (!snapshot || typeof snapshot !== "object") {
+    return;
+  }
+
+  state.serialSession = {
+    connected: snapshot.connected === true,
+    portPath: typeof snapshot.portPath === "string" ? snapshot.portPath : null,
+    baudRate: typeof snapshot.baudRate === "number" ? snapshot.baudRate : null,
+    busy: snapshot.busy === true,
+    idleTimeoutMs:
+      typeof snapshot.idleTimeoutMs === "number"
+        ? snapshot.idleTimeoutMs
+        : state.serialSession.idleTimeoutMs,
+    lastUsedAt: typeof snapshot.lastUsedAt === "number" ? snapshot.lastUsedAt : null,
+  };
+  syncControllerUi();
+}
+
+async function loadSerialSessionStatus() {
+  try {
+    const response = await fetch("/api/serial-session/status");
+    const payload = await response.json();
+
+    if (!response.ok) {
+      throw new Error(payload.error ?? "读取串口连接状态失败");
+    }
+
+    applySerialSessionSnapshot(payload);
+  } catch {
+    applySerialSessionSnapshot({
+      connected: false,
+      portPath: null,
+      baudRate: null,
+      busy: false,
+      idleTimeoutMs: state.serialSession.idleTimeoutMs,
+      lastUsedAt: null,
+    });
+  }
+}
+
+function renderSerialSessionStatus() {
+  const session = state.serialSession;
+  const idleMinutes = Math.max(1, Math.round(session.idleTimeoutMs / 60_000));
+
+  if (session.busy) {
+    els.controllerSerialSessionStatus.textContent =
+      session.portPath && session.baudRate
+        ? `串口正在使用中：${session.portPath} @ ${session.baudRate}。`
+        : "串口命令正在执行中。";
+    return;
+  }
+
+  if (session.connected) {
+    els.controllerSerialSessionStatus.textContent =
+      `串口保持连接：${session.portPath ?? "-"} @ ${session.baudRate ?? "-"}，空闲 ${idleMinutes} 分钟后自动断开。`;
+    return;
+  }
+
+  els.controllerSerialSessionStatus.textContent = "串口会在首次发送测试命令时自动连接。";
 }
 
 function setControllerStatus(partialStatus) {
@@ -1424,9 +1530,11 @@ function syncControllerUi() {
   els.controllerInfoButton.disabled = shouldDisable;
   els.controllerResetButton.disabled = shouldDisable;
   els.controllerSendCustomButton.disabled = shouldDisable;
+  els.controllerDisconnectButton.disabled = state.controller.busy || !state.serialSession.connected;
   els.controllerActionButtons.forEach((button) => {
     button.disabled = shouldDisable;
   });
+  renderSerialSessionStatus();
 }
 
 async function runExecution({
@@ -1459,9 +1567,11 @@ async function runExecution({
     const payload = await response.json();
 
     if (!response.ok) {
+      applySerialSessionSnapshot(payload.session);
       throw new Error(payload.error ?? "执行失败");
     }
 
+    applySerialSessionSnapshot(payload.session);
     appendLog(logTarget, `${successLabel}完成：${payload.totalCommands} 条命令，目标 ${payload.target}`);
     (payload.lines ?? []).forEach((line) => appendLog(logTarget, `[device] ${line}`));
     return payload;
@@ -1926,7 +2036,13 @@ async function init() {
     STUDIO_IMAGE_OFFSET_LIMITS,
   );
   syncStudioColorCountOptions();
-  await Promise.all([refreshPorts(), loadFirmwareInfo(), loadOfficialPalette(), pollStudioExecutionStatus()]);
+  await Promise.all([
+    refreshPorts(),
+    loadFirmwareInfo(),
+    loadOfficialPalette(),
+    loadSerialSessionStatus(),
+    pollStudioExecutionStatus(),
+  ]);
   renderPortSelects();
   syncStudioUi();
   syncFirmwareUi();

--- a/apps/desktop/src/web/static/index.html
+++ b/apps/desktop/src/web/static/index.html
@@ -522,7 +522,9 @@
               <button id="controller-refresh-button" class="ghost" type="button">刷新串口</button>
               <button id="controller-info-button" class="ghost" type="button">连接手柄</button>
               <button id="controller-reset-button" class="ghost" type="button">重置手柄蓝牙</button>
+              <button id="controller-disconnect-button" class="ghost" type="button">断开串口</button>
             </div>
+            <p id="controller-serial-session-status" class="hint">串口会在首次发送测试命令时自动连接。</p>
 
             <div class="controller-test-layout">
               <div class="test-block">


### PR DESCRIPTION
## Summary
- Introduce a shared serial session manager with idle timeout, explicit disconnect, and session snapshots
- Reuse the managed serial session across serial command flows and release it before firmware flashing
- Surface session status and disconnect controls in the desktop UI

## Testing
- Not run (not requested)

Closes https://github.com/zhouxiyu1997/friendmaker/issues/3