### PR TITLE
fix: Correcting the sendability determination of the controller connection status

### DIFF
--- a/apps/desktop/src/web/static/app.js
+++ b/apps/desktop/src/web/static/app.js
@@ -1404,6 +1404,10 @@ function boolLabel(value, labels) {
   return "未知";
 }
 
+function isControllerSendableStatus({ connected, paired, ready }) {
+  return ready === true || (connected === true && paired === true);
+}
+
 function applySerialSessionSnapshot(snapshot) {
   if (!snapshot || typeof snapshot !== "object") {
     return;
@@ -1487,7 +1491,9 @@ function updateControllerStatusFromLines(lines) {
   const authComplete = boolFromInfo(info.bt_auth_complete);
   const connected = boolFromInfo(info.bt_connected);
   const paired = boolFromInfo(info.bt_paired);
-  const ready = boolFromInfo(info.bt_ready_for_reports);
+  const rawReady = boolFromInfo(info.bt_ready_for_reports);
+  const ready = isControllerSendableStatus({ connected, paired, ready: rawReady });
+  const readyInferredFromPairing = rawReady !== true && connected === true && paired === true;
   const initError = info.bt_init_error ?? "-";
 
   let tone = "idle";
@@ -1504,7 +1510,9 @@ function updateControllerStatusFromLines(lines) {
     tone = "success";
     pill = "已就绪";
     title = "手柄已连接";
-    detail = "开发板已经完成连接并可发送按钮和摇杆报告，可以继续做手柄测试。";
+    detail = readyInferredFromPairing
+      ? "开发板已经完成 HID 连接和配对；固件报告通道字段可能滞后，但当前状态已经可以发送按钮和摇杆报告。"
+      : "开发板已经完成连接并可发送按钮和摇杆报告，可以继续做手柄测试。";
   } else if (connected === true) {
     tone = "running";
     pill = "已连接";

--- a/firmware/esp32/src/classic_bt_controller_transport.cpp
+++ b/firmware/esp32/src/classic_bt_controller_transport.cpp
@@ -651,7 +651,7 @@ void ClassicBtControllerTransport::printStatus(Print &output) const {
   output.print("INFO bt_paired=");
   output.println(boolName(paired_));
   output.print("INFO bt_ready_for_reports=");
-  output.println(boolName(readyForReports_));
+  output.println(boolName(isControllerInputReady()));
   output.print("INFO bt_init_step=");
   output.println(initStep_);
   output.print("INFO bt_init_error=");
@@ -687,7 +687,17 @@ void ClassicBtControllerTransport::printStatus(Print &output) const {
 
 const char *ClassicBtControllerTransport::name() const { return CONTROL_TRANSPORT; }
 
+bool ClassicBtControllerTransport::isHidReportChannelOpen() const {
+  return connected_ && appRegistered_ && hidReady_;
+}
+
+bool ClassicBtControllerTransport::isControllerInputReady() const {
+  return isHidReportChannelOpen() && paired_;
+}
+
 bool ClassicBtControllerTransport::sendCurrentInputReport(bool logFailure) {
+  readyForReports_ = isHidReportChannelOpen();
+
   if (!readyForReports_) {
     if (logFailure) {
       Serial.println("WARN bt report skipped reason=not-ready");
@@ -711,7 +721,7 @@ bool ClassicBtControllerTransport::sendCurrentInputReport(bool logFailure) {
     lastSendReportStatus_ = static_cast<int>(err);
     lastSendReportReason_ = 0;
     lastSendReportId_ = 0x30;
-    readyForReports_ = false;
+    readyForReports_ = isHidReportChannelOpen();
     if (logFailure) {
       Serial.printf(
           "WARN bt send_report failed err=%s connected=%s fail_count=%lu\n",
@@ -728,6 +738,8 @@ bool ClassicBtControllerTransport::sendCurrentInputReport(bool logFailure) {
 
 bool ClassicBtControllerTransport::sendSubcommandReply(
     uint8_t reportId, const uint8_t *data, size_t length, const char *label) {
+  readyForReports_ = isHidReportChannelOpen();
+
   if (!readyForReports_) {
     Serial.printf("WARN bt reply skipped reason=not-ready label=%s\n", label);
     return false;
@@ -743,7 +755,7 @@ bool ClassicBtControllerTransport::sendSubcommandReply(
     lastSendReportStatus_ = static_cast<int>(err);
     lastSendReportReason_ = 0;
     lastSendReportId_ = reportId;
-    readyForReports_ = false;
+    readyForReports_ = isHidReportChannelOpen();
     Serial.printf(
         "WARN bt reply failed label=%s err=%s fail_count=%lu\n",
         label,
@@ -986,7 +998,7 @@ void ClassicBtControllerTransport::handleHidEvent(int event, void *rawParam) {
       lastSendReportStatus_ = param->send_report.status;
       lastSendReportReason_ = param->send_report.reason;
       lastSendReportId_ = param->send_report.report_id;
-      readyForReports_ = param->send_report.status == ESP_HIDD_SUCCESS && connected_;
+      readyForReports_ = isHidReportChannelOpen();
       if (param->send_report.status != ESP_HIDD_SUCCESS) {
         Serial.printf(
             "WARN bt hid event=send-report status=%d reason=%u report=%u\n",
@@ -1109,6 +1121,8 @@ void ClassicBtControllerTransport::setLeftStickFromVector(int x, int y) {
 }
 void ClassicBtControllerTransport::updateInputReport() {}
 void ClassicBtControllerTransport::ensureSendTask() {}
+bool ClassicBtControllerTransport::isHidReportChannelOpen() const { return false; }
+bool ClassicBtControllerTransport::isControllerInputReady() const { return false; }
 bool ClassicBtControllerTransport::sendCurrentInputReport(bool logFailure) {
   (void)logFailure;
   return false;

--- a/firmware/esp32/src/classic_bt_controller_transport.h
+++ b/firmware/esp32/src/classic_bt_controller_transport.h
@@ -24,6 +24,8 @@ class ClassicBtControllerTransport : public ControllerTransport {
   void setLeftStickFromVector(int x, int y);
   void updateInputReport();
   void ensureSendTask();
+  bool isHidReportChannelOpen() const;
+  bool isControllerInputReady() const;
   bool sendCurrentInputReport(bool logFailure);
   bool sendSubcommandReply(uint8_t reportId, const uint8_t *data, size_t length, const char *label);
   bool attemptVirtualCablePlug(const uint8_t peerAddress[6], const char *reason);


### PR DESCRIPTION
## Summary
- Adjusted the front-end connection status judgment to include "connected + paired" as ready to send, preventing the status from remaining in "not ready" for extended periods.
- Unified the status output on the firmware side, ensuring that `bt_ready_for_reports` reflects actual operable conditions, rather than the instantaneous result of an asynchronous send callback.
- Retained existing logs and interaction flows, only modifying the status check logic.

## Testing
- `npm run check` pass
- `npm run build` pass
- `node --check apps/desktop/src/web/static/app.js` pass
- `git diff --check` pass