### PR TITLE
fix: drawing offset

### DIFF
--- a/apps/desktop/src/app/generateDrawPlan.ts
+++ b/apps/desktop/src/app/generateDrawPlan.ts
@@ -4,6 +4,7 @@ import { renderPreviewToBuffer } from "../image/renderPreview.js";
 import { estimateRuntimeMs, generateScanlineCommands } from "../path/scanline.js";
 import { serializeCommands } from "../protocol/serializer.js";
 import type { CanvasBounds, DrawingProfile, PixelMap } from "../types.js";
+import { gridCellToCanvasRect, resolveBrushGrid } from "../path/brushGrid.js";
 
 export interface DrawPlan {
   commands: string[];
@@ -57,7 +58,7 @@ export async function generateDrawPlan(
 }
 
 function calculateCanvasBounds(pixelMap: PixelMap, profile: DrawingProfile): CanvasBounds | null {
-  const brushSize = Math.max(1, profile.brushSize);
+  const grid = resolveBrushGrid(profile);
   let minX = Number.POSITIVE_INFINITY;
   let minY = Number.POSITIVE_INFINITY;
   let maxX = -1;
@@ -69,15 +70,12 @@ function calculateCanvasBounds(pixelMap: PixelMap, profile: DrawingProfile): Can
         continue;
       }
 
-      const startX = pixel.x * brushSize;
-      const startY = pixel.y * brushSize;
-      const endX = Math.min(profile.canvasWidth, startX + brushSize) - 1;
-      const endY = Math.min(profile.canvasHeight, startY + brushSize) - 1;
+      const rect = gridCellToCanvasRect(pixel, grid);
 
-      minX = Math.min(minX, startX);
-      minY = Math.min(minY, startY);
-      maxX = Math.max(maxX, endX);
-      maxY = Math.max(maxY, endY);
+      minX = Math.min(minX, rect.x);
+      minY = Math.min(minY, rect.y);
+      maxX = Math.max(maxX, rect.maxX);
+      maxY = Math.max(maxY, rect.maxY);
     }
   }
 

--- a/apps/desktop/src/image/pixelize.ts
+++ b/apps/desktop/src/image/pixelize.ts
@@ -3,27 +3,21 @@ import type { ImageSource } from "./loadImage.js";
 import { autoRemoveBackground } from "./removeBackground.js";
 import { resizeImage } from "./resizeImage.js";
 import { quantizePixels } from "./quantize.js";
+import { resolveBrushGrid } from "../path/brushGrid.js";
 
 function collapsePixelMapForBrush(
   pixelMap: PixelizationResult["pixelMap"],
   profile: DrawingProfile,
 ): PixelizationResult["pixelMap"] {
-  const brushSize = Math.max(1, profile.brushSize);
-
-  if (brushSize === 1) {
-    return pixelMap;
-  }
-
-  const logicalWidth = Math.max(1, Math.ceil(profile.canvasWidth / brushSize));
-  const logicalHeight = Math.max(1, Math.ceil(profile.canvasHeight / brushSize));
+  const grid = resolveBrushGrid(profile);
   const collapsed: PixelizationResult["pixelMap"] = [];
 
-  for (let logicalY = 0; logicalY < logicalHeight; logicalY += 1) {
+  for (let logicalY = 0; logicalY < grid.gridHeight; logicalY += 1) {
     const row = [];
-    const originY = logicalY * brushSize;
+    const originY = grid.originY + logicalY * grid.brushSize;
 
-    for (let logicalX = 0; logicalX < logicalWidth; logicalX += 1) {
-      const originX = logicalX * brushSize;
+    for (let logicalX = 0; logicalX < grid.gridWidth; logicalX += 1) {
+      const originX = grid.originX + logicalX * grid.brushSize;
       const colorCounts = new Map<
         number,
         {
@@ -39,7 +33,7 @@ function collapsePixelMapForBrush(
           }
         | null = null;
 
-      for (let dy = 0; dy < brushSize; dy += 1) {
+      for (let dy = 0; dy < grid.brushSize; dy += 1) {
         const y = originY + dy;
 
         if (y >= pixelMap.length) {
@@ -52,7 +46,7 @@ function collapsePixelMapForBrush(
           continue;
         }
 
-        for (let dx = 0; dx < brushSize; dx += 1) {
+        for (let dx = 0; dx < grid.brushSize; dx += 1) {
           const x = originX + dx;
 
           if (x >= sourceRow.length) {

--- a/apps/desktop/src/image/renderPreview.ts
+++ b/apps/desktop/src/image/renderPreview.ts
@@ -3,6 +3,7 @@ import sharp from "sharp";
 import type { DrawingProfile, PixelMap } from "../types.js";
 import { ensureParentDirectory } from "../utils/fs.js";
 import { parseHexColor } from "../utils/colors.js";
+import { gridCellToCanvasRect, resolveBrushGrid } from "../path/brushGrid.js";
 
 function buildPreviewBuffer(pixelMap: PixelMap, profile: DrawingProfile): Buffer {
   const height = profile.canvasHeight;
@@ -13,7 +14,7 @@ function buildPreviewBuffer(pixelMap: PixelMap, profile: DrawingProfile): Buffer
   }
 
   const buffer = Buffer.alloc(width * height * 4);
-  const brushSize = Math.max(1, profile.brushSize);
+  const grid = resolveBrushGrid(profile);
 
   for (const row of pixelMap) {
     for (const pixel of row) {
@@ -22,21 +23,20 @@ function buildPreviewBuffer(pixelMap: PixelMap, profile: DrawingProfile): Buffer
       }
 
       const color = parseHexColor(pixel.colorHex);
-      const originX = pixel.x * brushSize;
-      const originY = pixel.y * brushSize;
+      const rect = gridCellToCanvasRect(pixel, grid);
 
-      for (let dy = 0; dy < brushSize; dy += 1) {
-        const canvasY = originY + dy;
+      for (let dy = 0; dy < rect.height; dy += 1) {
+        const canvasY = rect.y + dy;
 
-        if (canvasY >= height) {
-          break;
+        if (canvasY < 0 || canvasY >= height) {
+          continue;
         }
 
-        for (let dx = 0; dx < brushSize; dx += 1) {
-          const canvasX = originX + dx;
+        for (let dx = 0; dx < rect.width; dx += 1) {
+          const canvasX = rect.x + dx;
 
-          if (canvasX >= width) {
-            break;
+          if (canvasX < 0 || canvasX >= width) {
+            continue;
           }
 
           const offset = (canvasY * width + canvasX) * 4;

--- a/apps/desktop/src/path/brushGrid.ts
+++ b/apps/desktop/src/path/brushGrid.ts
@@ -1,0 +1,52 @@
+import type { DrawingProfile } from "../types.js";
+
+export interface BrushGrid {
+  brushSize: number;
+  gridWidth: number;
+  gridHeight: number;
+  originX: number;
+  originY: number;
+  centerOffset: number;
+}
+
+export function resolveBrushGrid(profile: DrawingProfile): BrushGrid {
+  const brushSize = Math.max(1, profile.brushSize);
+  const gridWidth = Math.floor(Math.max(0, profile.canvasWidth) / brushSize);
+  const gridHeight = Math.floor(Math.max(0, profile.canvasHeight) / brushSize);
+
+  return {
+    brushSize,
+    gridWidth,
+    gridHeight,
+    originX: Math.floor((profile.canvasWidth - gridWidth * brushSize) / 2),
+    originY: Math.floor((profile.canvasHeight - gridHeight * brushSize) / 2),
+    centerOffset: Math.floor(brushSize / 2),
+  };
+}
+
+export function gridCellToCanvasCenter(
+  point: { x: number; y: number },
+  grid: BrushGrid,
+): { x: number; y: number } {
+  return {
+    x: grid.originX + point.x * grid.brushSize + grid.centerOffset,
+    y: grid.originY + point.y * grid.brushSize + grid.centerOffset,
+  };
+}
+
+export function gridCellToCanvasRect(
+  point: { x: number; y: number },
+  grid: BrushGrid,
+): { x: number; y: number; width: number; height: number; maxX: number; maxY: number } {
+  const x = grid.originX + point.x * grid.brushSize;
+  const y = grid.originY + point.y * grid.brushSize;
+
+  return {
+    x,
+    y,
+    width: grid.brushSize,
+    height: grid.brushSize,
+    maxX: x + grid.brushSize - 1,
+    maxY: y + grid.brushSize - 1,
+  };
+}

--- a/apps/desktop/src/path/scanline.ts
+++ b/apps/desktop/src/path/scanline.ts
@@ -7,10 +7,12 @@ import {
   drawCommand,
   endCommand,
   homeCommand,
+  lineCommand,
   moveCommand,
   paletteConfigCommand,
   type DrawCommand,
 } from "../protocol/commands.js";
+import { gridCellToCanvasCenter, resolveBrushGrid } from "./brushGrid.js";
 
 const PALETTE_SLOT_COUNT = 9;
 const NEIGHBOR_OFFSETS = [
@@ -19,6 +21,12 @@ const NEIGHBOR_OFFSETS = [
   { dx: 0, dy: 1 },
   { dx: 0, dy: -1 },
 ];
+
+interface PixelRun {
+  start: Pixel;
+  end: Pixel;
+  count: number;
+}
 
 function getPixelsByColor(pixelMap: PixelMap, colorIndex: number): Pixel[] {
   return pixelMap.flatMap((row) =>
@@ -256,13 +264,7 @@ function toCanvasPosition(
   point: { x: number; y: number },
   profile: DrawingProfile,
 ): { x: number; y: number } {
-  const step = Math.max(1, profile.brushSize);
-  const brushCenterOffset = Math.floor(step / 2);
-
-  return {
-    x: Math.min(point.x * step + brushCenterOffset, profile.canvasWidth - 1),
-    y: Math.min(point.y * step + brushCenterOffset, profile.canvasHeight - 1),
-  };
+  return gridCellToCanvasCenter(point, resolveBrushGrid(profile));
 }
 
 function moveTo(
@@ -339,6 +341,134 @@ function getUsedPaletteColors(pixelMap: PixelMap): Array<{ colorIndex: number; c
     .map(([colorIndex, colorHex]) => ({ colorIndex, colorHex }));
 }
 
+function buildHorizontalRuns(pixels: Pixel[]): PixelRun[] {
+  const rows = new Map<number, Pixel[]>();
+
+  for (const pixel of pixels) {
+    const row = rows.get(pixel.y);
+
+    if (row) {
+      row.push(pixel);
+    } else {
+      rows.set(pixel.y, [pixel]);
+    }
+  }
+
+  const runs: PixelRun[] = [];
+
+  for (const [, row] of Array.from(rows.entries()).sort((left, right) => left[0] - right[0])) {
+    const sorted = [...row].sort((left, right) => left.x - right.x);
+    let start: Pixel | null = null;
+    let end: Pixel | null = null;
+    let count = 0;
+
+    for (const pixel of sorted) {
+      if (!start || !end || pixel.x !== end.x + 1) {
+        if (start && end) {
+          runs.push({ start, end, count });
+        }
+
+        start = pixel;
+        end = pixel;
+        count = 1;
+        continue;
+      }
+
+      end = pixel;
+      count += 1;
+    }
+
+    if (start && end) {
+      runs.push({ start, end, count });
+    }
+  }
+
+  return runs;
+}
+
+function reverseRun(run: PixelRun): PixelRun {
+  return {
+    start: run.end,
+    end: run.start,
+    count: run.count,
+  };
+}
+
+function getRunStartDistance(
+  run: PixelRun,
+  current: { x: number; y: number },
+  profile: DrawingProfile,
+): number {
+  const start = toCanvasPosition(run.start, profile);
+  return Math.abs(start.x - current.x) + Math.abs(start.y - current.y);
+}
+
+function orderRunsFromCursor(
+  runs: PixelRun[],
+  current: { x: number; y: number },
+  profile: DrawingProfile,
+): PixelRun[] {
+  const remaining = [...runs];
+  const ordered: PixelRun[] = [];
+  let currentPosition = current;
+
+  while (remaining.length > 0) {
+    let bestIndex = 0;
+    let bestRun = remaining[0]!;
+    let bestDistance = Number.POSITIVE_INFINITY;
+
+    remaining.forEach((run, index) => {
+      const forwardDistance = getRunStartDistance(run, currentPosition, profile);
+      const reversed = reverseRun(run);
+      const reverseDistance = getRunStartDistance(reversed, currentPosition, profile);
+
+      if (forwardDistance < bestDistance) {
+        bestDistance = forwardDistance;
+        bestIndex = index;
+        bestRun = run;
+      }
+
+      if (reverseDistance < bestDistance) {
+        bestDistance = reverseDistance;
+        bestIndex = index;
+        bestRun = reversed;
+      }
+    });
+
+    ordered.push(bestRun);
+    currentPosition = toCanvasPosition(bestRun.end, profile);
+    remaining.splice(bestIndex, 1);
+  }
+
+  return ordered;
+}
+
+function appendDrawPixels(
+  commands: DrawCommand[],
+  pixels: Pixel[],
+  current: { x: number; y: number },
+  profile: DrawingProfile,
+): { x: number; y: number } {
+  let currentPosition = current;
+  const runs = orderRunsFromCursor(buildHorizontalRuns(pixels), current, profile);
+
+  for (const run of runs) {
+    commands.push(...moveTo(currentPosition, run.start, profile));
+    const startPosition = toCanvasPosition(run.start, profile);
+    const endPosition = toCanvasPosition(run.end, profile);
+
+    if (run.count <= 1) {
+      commands.push(drawCommand(profile.drawButton));
+    } else {
+      commands.push(lineCommand(endPosition.x - startPosition.x, endPosition.y - startPosition.y));
+    }
+
+    currentPosition = endPosition;
+  }
+
+  return currentPosition;
+}
+
 export function generateScanlineCommands(
   pixelMap: PixelMap,
   profile: DrawingProfile,
@@ -373,12 +503,7 @@ export function generateScanlineCommands(
       }
 
       const orderedPixels = getOrderedPixelsForColor(pixelMap, colorIndex, current, profile);
-
-      for (const pixel of orderedPixels) {
-        commands.push(...moveTo(current, pixel, profile));
-        commands.push(drawCommand(profile.drawButton));
-        current = toCanvasPosition(pixel, profile);
-      }
+      current = appendDrawPixels(commands, orderedPixels, current, profile);
     }
   } else if (profile.colorMode === "palette") {
     const usedColors = getUsedPaletteColors(pixelMap);
@@ -398,12 +523,7 @@ export function generateScanlineCommands(
         }
 
         const orderedPixels = getOrderedPixelsForColor(pixelMap, color.colorIndex, current, profile);
-
-        for (const pixel of orderedPixels) {
-          commands.push(...moveTo(current, pixel, profile));
-          commands.push(drawCommand(profile.drawButton));
-          current = toCanvasPosition(pixel, profile);
-        }
+        current = appendDrawPixels(commands, orderedPixels, current, profile);
       }
     }
   } else {
@@ -431,12 +551,7 @@ export function generateScanlineCommands(
         }
 
         const orderedPixels = getOrderedPixelsForColor(pixelMap, color.colorIndex, current, profile);
-
-        for (const pixel of orderedPixels) {
-          commands.push(...moveTo(current, pixel, profile));
-          commands.push(drawCommand(profile.drawButton));
-          current = toCanvasPosition(pixel, profile);
-        }
+        current = appendDrawPixels(commands, orderedPixels, current, profile);
       }
     }
   }
@@ -459,6 +574,12 @@ export function estimateRuntimeMs(commands: DrawCommand[], profile: DrawingProfi
       case "draw":
       case "press":
         return total + profile.buttonPressDuration + profile.inputDelay;
+      case "line":
+        return (
+          total +
+          (Math.abs(command.dx) + Math.abs(command.dy) + 1) *
+            (profile.buttonPressDuration + profile.inputDelay)
+        );
       case "color":
         return total + profile.colorChangeDuration;
       case "paletteConfig":

--- a/apps/desktop/src/protocol/commands.ts
+++ b/apps/desktop/src/protocol/commands.ts
@@ -4,6 +4,7 @@ export type DrawCommand =
   | { type: "home" }
   | { type: "move"; dx: number; dy: number }
   | { type: "draw"; button: ControllerButton }
+  | { type: "line"; dx: number; dy: number }
   | { type: "press"; button: ControllerButton }
   | { type: "color"; index: number }
   | { type: "basicPaletteReset" }
@@ -24,6 +25,10 @@ export function moveCommand(dx: number, dy: number): DrawCommand {
 
 export function drawCommand(button: ControllerButton): DrawCommand {
   return { type: "draw", button };
+}
+
+export function lineCommand(dx: number, dy: number): DrawCommand {
+  return { type: "line", dx, dy };
 }
 
 export function pressButtonCommand(button: ControllerButton): DrawCommand {

--- a/apps/desktop/src/protocol/serializer.ts
+++ b/apps/desktop/src/protocol/serializer.ts
@@ -8,6 +8,8 @@ export function serializeCommand(command: DrawCommand): string {
       return `M ${command.dx} ${command.dy}`;
     case "draw":
       return "P";
+    case "line":
+      return `L ${command.dx} ${command.dy}`;
     case "press":
       return command.button;
     case "color":

--- a/apps/desktop/src/serial/sender.ts
+++ b/apps/desktop/src/serial/sender.ts
@@ -201,8 +201,8 @@ function getAckTimeoutForCommand(command: string, baseTimeoutMs: number): number
     return Math.max(baseTimeoutMs, 20_000);
   }
 
-  if (trimmed.startsWith("M ")) {
-    const match = /^M\s+(-?\d+)\s+(-?\d+)$/u.exec(trimmed);
+  if (trimmed.startsWith("M ") || trimmed.startsWith("L ")) {
+    const match = /^[ML]\s+(-?\d+)\s+(-?\d+)$/u.exec(trimmed);
 
     if (!match || match[1] === undefined || match[2] === undefined) {
       return baseTimeoutMs;
@@ -212,8 +212,8 @@ function getAckTimeoutForCommand(command: string, baseTimeoutMs: number): number
     const dy = Number.parseInt(match[2], 10);
     const steps = Math.abs(dx) + Math.abs(dy);
 
-    // Each move step becomes one D-pad press on the ESP32 side. Give the board
-    // enough room to finish long center-to-target moves before we expect `OK`.
+    // Each move/line step becomes one D-pad press on the ESP32 side. Give the
+    // board enough room to finish long center-to-target moves before `OK`.
     return Math.max(baseTimeoutMs, 1_500 + steps * 150);
   }
 

--- a/apps/desktop/src/simulator/device.ts
+++ b/apps/desktop/src/simulator/device.ts
@@ -243,6 +243,21 @@ export class SimulatedDevice {
       return this.cacheAndReturn(frame, this.makeAck(frame), lines);
     }
 
+    if (trimmed.startsWith("L ")) {
+      const parsed = parseTwoInts(trimmed);
+
+      if (!parsed || (parsed.first !== 0 && parsed.second !== 0)) {
+        await delay(options.ackDelayMs);
+        return this.cacheAndReturn(frame, this.makeError(frame, "invalid line"), lines);
+      }
+
+      this.state.drawCount += Math.abs(parsed.first) + Math.abs(parsed.second) + 1;
+      this.state.x += parsed.first;
+      this.state.y += parsed.second;
+      await delay(options.ackDelayMs);
+      return this.cacheAndReturn(frame, this.makeAck(frame), lines);
+    }
+
     if (trimmed.startsWith("C ")) {
       const colorIndex = parseOneInt(trimmed);
 

--- a/apps/desktop/src/web/static/app.js
+++ b/apps/desktop/src/web/static/app.js
@@ -1716,6 +1716,7 @@ function syncStudioUi() {
     ? "已开启自动扣背景，会优先去掉白底、浅灰底和棋盘格假透明背景。"
     : "当前不会自动扣背景；如果素材是白底或棋盘格假透明图，建议开启。";
   const squareBrushHint = "建议同时把 Switch 里的笔刷切到方块笔刷，整体观感通常会更美观。";
+  const firmwareLineHint = "偏移修复和连画脚本需要先刷入最新固件。";
   const scaleHint = `当前导入缩放是 ${state.studio.imageScalePercent}%，100% 表示完整放进画布。`;
   const positionHint = describeImagePosition(
     state.studio.imageOffsetXPercent,
@@ -1723,8 +1724,8 @@ function syncStudioUi() {
   );
   els.studioModeHint.textContent =
     state.studio.colorMode === "mono"
-      ? `深色像素会绘制，浅色像素会保留为空白背景。当前会先按 ${state.studio.imageScalePercent}% 调整图片大小，再放进 256x256 脚本坐标画布，并按 ${state.studio.brushSize} 号笔和画布中心起步生成。${scaleHint}${positionHint}${squareBrushHint}${backgroundHint}`
-      : `当前会先按 ${state.studio.imageScalePercent}% 调整图片大小，再把图片压到 ${state.studio.colorCount} 个官方色以内，并映射到游戏内置的 7x12 官方色盘，再按 ${state.studio.brushSize} 号笔生成。${scaleHint}${positionHint}开始前请保持右侧 9 个槽位默认颜色不变。${squareBrushHint}${backgroundHint}`;
+      ? `深色像素会绘制，浅色像素会保留为空白背景。当前会先按 ${state.studio.imageScalePercent}% 调整图片大小，再放进 256x256 脚本坐标画布，并按 ${state.studio.brushSize} 号笔和画布中心起步生成。${scaleHint}${positionHint}${squareBrushHint}${backgroundHint}${firmwareLineHint}`
+      : `当前会先按 ${state.studio.imageScalePercent}% 调整图片大小，再把图片压到 ${state.studio.colorCount} 个官方色以内，并映射到游戏内置的 7x12 官方色盘，再按 ${state.studio.brushSize} 号笔生成。${scaleHint}${positionHint}开始前请保持右侧 9 个槽位默认颜色不变。${squareBrushHint}${backgroundHint}${firmwareLineHint}`;
   els.studioPortSelect.disabled = state.studio.busy || executionActive;
   els.refreshPortsButton.disabled = state.studio.busy || executionActive;
   els.sizeSelect.disabled = state.studio.busy || executionActive;
@@ -1801,8 +1802,8 @@ function syncStudioUi() {
 
   els.executionHint.textContent =
     state.studio.colorMode === "mono"
-      ? `当前会把按 ${state.studio.imageScalePercent}% 缩放、${describeImagePosition(state.studio.imageOffsetXPercent, state.studio.imageOffsetYPercent, false)}后的 256x256 黑白脚本通过串口发送到 ${state.selectedPortPath}，由 ESP32 从画布中心起步，按 ${state.studio.brushSize} 号笔继续翻译成方向键移动与 A 绘制。建议开始前把 Switch 里的笔刷切到方块笔刷，整体观感通常会更美观。`
-      : `当前会把按 ${state.studio.imageScalePercent}% 缩放、${describeImagePosition(state.studio.imageOffsetXPercent, state.studio.imageOffsetYPercent, false)}后的 256x256 官方色脚本通过串口发送到 ${state.selectedPortPath}。请先保持右侧 9 个槽位默认颜色不变，ESP32 会按这组默认槽位状态去配置内置 7x12 色盘，并按 ${state.studio.brushSize} 号笔绘制。建议开始前把 Switch 里的笔刷切到方块笔刷，整体观感通常会更美观。`;
+      ? `当前会把按 ${state.studio.imageScalePercent}% 缩放、${describeImagePosition(state.studio.imageOffsetXPercent, state.studio.imageOffsetYPercent, false)}后的 256x256 黑白脚本通过串口发送到 ${state.selectedPortPath}，由 ESP32 从画布中心起步，按 ${state.studio.brushSize} 号笔继续翻译成方向键移动与 A 连画。开始前请刷入最新固件，并把 Switch 里的笔刷切到方块笔刷。`
+      : `当前会把按 ${state.studio.imageScalePercent}% 缩放、${describeImagePosition(state.studio.imageOffsetXPercent, state.studio.imageOffsetYPercent, false)}后的 256x256 官方色脚本通过串口发送到 ${state.selectedPortPath}。请先刷入最新固件并保持右侧 9 个槽位默认颜色不变，ESP32 会按这组默认槽位状态去配置内置 7x12 色盘，并按 ${state.studio.brushSize} 号笔连画。`;
   renderStudioConnectionStatus();
 }
 

--- a/firmware/esp32/src/controller.cpp
+++ b/firmware/esp32/src/controller.cpp
@@ -139,6 +139,34 @@ void SwitchController::drawStroke() {
   transport_.pressButton(ControllerButton::A, BUTTON_PRESS_DURATION_MS, INPUT_DELAY_MS);
 }
 
+void SwitchController::drawLine(int dx, int dy) {
+  waitUntilReady();
+
+  if (dx != 0 && dy != 0) {
+    return;
+  }
+
+  transport_.pressButton(ControllerButton::A, BUTTON_PRESS_DURATION_MS, INPUT_DELAY_MS);
+
+  const int steps = abs(dx) + abs(dy);
+
+  if (steps == 0) {
+    return;
+  }
+
+  const ControllerButton directionButton =
+      dx < 0
+          ? ControllerButton::DpadLeft
+          : (dx > 0 ? ControllerButton::DpadRight
+                    : (dy < 0 ? ControllerButton::DpadUp : ControllerButton::DpadDown));
+  const uint32_t buttonsMask =
+      controllerButtonMask(ControllerButton::A) | controllerButtonMask(directionButton);
+
+  for (int step = 0; step < steps; step += 1) {
+    transport_.pressButtons(buttonsMask, BUTTON_PRESS_DURATION_MS, INPUT_DELAY_MS);
+  }
+}
+
 void SwitchController::pressButton(ControllerButton button) {
   waitUntilReady();
   transport_.pressButton(button, BUTTON_PRESS_DURATION_MS, INPUT_DELAY_MS);

--- a/firmware/esp32/src/controller.h
+++ b/firmware/esp32/src/controller.h
@@ -12,6 +12,7 @@ class SwitchController {
   void moveHome();
   void moveCursor(int dx, int dy);
   void drawStroke();
+  void drawLine(int dx, int dy);
   void pressButton(ControllerButton button);
   void holdButton(ControllerButton button, uint16_t holdMs);
   void tapButton(ControllerButton button, uint16_t count);

--- a/firmware/esp32/src/protocol.cpp
+++ b/firmware/esp32/src/protocol.cpp
@@ -384,6 +384,20 @@ bool executeCommand(const String &line, SwitchController &controller, String &er
     return true;
   }
 
+  if (line.startsWith("L ")) {
+    int dx = 0;
+    int dy = 0;
+
+    if (!parseTwoInts(line, dx, dy) || (dx != 0 && dy != 0)) {
+      error = "invalid line";
+      return false;
+    }
+
+    controller.drawLine(dx, dy);
+    Serial.printf("INFO action=line dx=%d dy=%d\n", dx, dy);
+    return true;
+  }
+
   ControllerButton holdButton = ControllerButton::A;
   uint16_t holdMs = 0;
 


### PR DESCRIPTION
## Summary
- 统一画笔网格与坐标换算，改为居中 origin + 画笔中心点，修复大笔刷下的绘制偏移
- 新增 `L <dx> <dy>` 连画协议，路径生成默认把同色连续横向像素合并为 run
- 同步更新串口发送、模拟器、ESP32 固件和 UI 提示，保证新脚本与新固件一致
- 保留拉取解包的 SwitchC 参考固件文件，便于对照分析

## Testing
- `npm run check` 通过
- 合成坐标与连画输出验证通过，覆盖 `brush 1/7/13` 的网格位置和连续/断开 run 场景
- 模拟器 `L` 命令的 ACK 与进度流程验证通过
- 本地未运行 ESP32 固件编译，需在具备 PlatformIO 环境后再做实机编译确认