### PR TITLE
Enable macOS code signing and notarization in CI

### DIFF
--- a/.github/workflows/electron-release-build.yml
+++ b/.github/workflows/electron-release-build.yml
@@ -44,7 +44,60 @@ jobs:
       - name: Type check
         run: npm run check
 
-      - name: Build installer
+      - name: Prepare Apple notarization key
+        if: runner.os == 'macOS'
+        shell: bash
+        env:
+          APPLE_API_ISSUER: ${{ secrets.APPLE_API_ISSUER }}
+          APPLE_API_KEY_BASE64: ${{ secrets.APPLE_API_KEY_BASE64 }}
+          APPLE_API_KEY_ID: ${{ secrets.APPLE_API_KEY_ID }}
+          CSC_KEY_PASSWORD: ${{ secrets.CSC_KEY_PASSWORD }}
+          CSC_LINK: ${{ secrets.CSC_LINK }}
+        run: |
+          set -euo pipefail
+
+          for name in APPLE_API_ISSUER APPLE_API_KEY_BASE64 APPLE_API_KEY_ID CSC_KEY_PASSWORD CSC_LINK; do
+            if [[ -z "${!name}" ]]; then
+              echo "::error::Missing required GitHub Actions secret: ${name}"
+              exit 1
+            fi
+          done
+
+          key_path="$RUNNER_TEMP/apple/AuthKey_${APPLE_API_KEY_ID}.p8"
+          mkdir -p "$(dirname "$key_path")"
+          printf '%s' "$APPLE_API_KEY_BASE64" | /usr/bin/base64 -D > "$key_path"
+          chmod 600 "$key_path"
+          echo "APPLE_API_KEY=$key_path" >> "$GITHUB_ENV"
+
+      - name: Build signed macOS installer
+        if: runner.os == 'macOS'
+        run: ${{ matrix.script }}
+        env:
+          APPLE_API_ISSUER: ${{ secrets.APPLE_API_ISSUER }}
+          APPLE_API_KEY_ID: ${{ secrets.APPLE_API_KEY_ID }}
+          CSC_KEY_PASSWORD: ${{ secrets.CSC_KEY_PASSWORD }}
+          CSC_LINK: ${{ secrets.CSC_LINK }}
+          CSC_IDENTITY_AUTO_DISCOVERY: "false"
+
+      - name: Verify macOS signature and notarization
+        if: runner.os == 'macOS'
+        shell: bash
+        run: |
+          set -euo pipefail
+
+          app_path="$(find release -maxdepth 3 -name 'Friend Maker.app' -type d | head -n 1)"
+          if [[ -z "$app_path" ]]; then
+            echo "::error::Cannot find packaged Friend Maker.app under release/"
+            find release -maxdepth 3 -print || true
+            exit 1
+          fi
+
+          codesign --verify --deep --strict --verbose=2 "$app_path"
+          xcrun stapler validate "$app_path"
+          spctl -a -vvv -t exec "$app_path"
+
+      - name: Build unsigned Windows installer
+        if: runner.os == 'Windows'
         run: ${{ matrix.script }}
         env:
           CSC_IDENTITY_AUTO_DISCOVERY: "false"

--- a/.github/workflows/electron-release-build.yml
+++ b/.github/workflows/electron-release-build.yml
@@ -77,7 +77,6 @@ jobs:
           APPLE_API_KEY_ID: ${{ secrets.APPLE_API_KEY_ID }}
           CSC_KEY_PASSWORD: ${{ secrets.CSC_KEY_PASSWORD }}
           CSC_LINK: ${{ secrets.CSC_LINK }}
-          CSC_IDENTITY_AUTO_DISCOVERY: "false"
 
       - name: Verify macOS signature and notarization
         if: runner.os == 'macOS'

--- a/package.json
+++ b/package.json
@@ -55,7 +55,9 @@
     "mac": {
       "icon": "build/icon.icns",
       "category": "public.app-category.utilities",
-      "identity": null,
+      "hardenedRuntime": true,
+      "forceCodeSigning": true,
+      "notarize": true,
       "target": [
         "dmg",
         "zip"


### PR DESCRIPTION
## Summary
- Removed the macOS `identity: null` override so electron-builder can sign the app in release builds.
- Added CI steps to decode the Apple API key, export notarization credentials, and run the macOS build with signing enabled.
- Added post-build verification with `codesign`, `stapler`, and `spctl` to catch signing or notarization failures early.
- Kept the Windows build path unchanged apart from making the OS-specific job split explicit.

## Testing
- `npm run check`
- Validated the updated `package.json` and GitHub Actions workflow structure locally.