### PR TITLE
fix: extend palette config ack timeout

### DIFF
--- a/apps/desktop/src/serial/sender.ts
+++ b/apps/desktop/src/serial/sender.ts
@@ -18,6 +18,21 @@ import type { ProgressUpdate, SenderControls } from "../types.js";
 const ACK_LINE_PREFIXES = ["OK ", "ERR "] as const;
 const DEVICE_LINE_PREFIXES = ["INFO ", "WARN ", "BOOT ", "rst:"] as const;
 export const DEFAULT_SERIAL_SESSION_IDLE_TIMEOUT_MS = 15 * 60 * 1_000;
+const COLOR_PALETTE_SLOT_COUNT = 9;
+const COLOR_PALETTE_RESET_TO_BOTTOM_STEPS = 18;
+const COLOR_PALETTE_MENU_PRESS_DURATION_MS = 90;
+const COLOR_PALETTE_MENU_INPUT_DELAY_MS = 90;
+const COLOR_PALETTE_MENU_OPEN_SETTLE_MS = 180;
+const COLOR_PALETTE_EDITOR_OPEN_SETTLE_MS = 180;
+const COLOR_PALETTE_EDITOR_HUE_RESET_HOLD_MS = 2_500;
+const COLOR_PALETTE_EDITOR_HUE_STEP_COUNT = 200;
+const COLOR_PALETTE_EDITOR_SATURATION_STEP_COUNT = 213;
+const COLOR_PALETTE_EDITOR_VALUE_STEP_COUNT = 112;
+const COLOR_PALETTE_EDITOR_RESET_UP_HOLD_MS = 1_500;
+const COLOR_PALETTE_EDITOR_RESET_LEFT_HOLD_MS = 3_000;
+const COLOR_PALETTE_EDITOR_MOVE_STEP_MS = 20;
+const BASIC_COLOR_TAB_SETTLE_MS = 140;
+const PALETTE_CONFIG_TIMEOUT_MARGIN_MS = 2_000;
 
 interface SerialCommandSendOptions {
   ackTimeoutMs: number;
@@ -36,6 +51,100 @@ export interface SerialSessionSnapshot {
   busy: boolean;
   idleTimeoutMs: number;
   lastUsedAt: number | null;
+}
+
+interface HsvColor {
+  hue: number;
+  saturation: number;
+  value: number;
+}
+
+function clampPaletteSlotIndex(index: number): number {
+  if (index < 0) {
+    return 0;
+  }
+
+  if (index >= COLOR_PALETTE_SLOT_COUNT) {
+    return COLOR_PALETTE_SLOT_COUNT - 1;
+  }
+
+  return index;
+}
+
+function scaleChannelToSteps(value: number, steps: number): number {
+  if (steps <= 0) {
+    return 0;
+  }
+
+  const clamped = value < 0 ? 0 : value > 1 ? 1 : value;
+  return Math.round(clamped * steps);
+}
+
+function rgbToHsv(red: number, green: number, blue: number): HsvColor {
+  const r = red / 255;
+  const g = green / 255;
+  const b = blue / 255;
+  const maxChannel = Math.max(r, g, b);
+  const minChannel = Math.min(r, g, b);
+  const delta = maxChannel - minChannel;
+  let hue = 0;
+
+  if (delta > 0) {
+    if (maxChannel === r) {
+      hue = 60 * (((g - b) / delta) % 6);
+    } else if (maxChannel === g) {
+      hue = 60 * (((b - r) / delta) + 2);
+    } else {
+      hue = 60 * (((r - g) / delta) + 4);
+    }
+  }
+
+  if (hue < 0) {
+    hue += 360;
+  }
+
+  return {
+    hue,
+    saturation: maxChannel <= 0 ? 0 : delta / maxChannel,
+    value: maxChannel,
+  };
+}
+
+function estimatePaletteConfigDurationMs(
+  slotIndex: number,
+  red: number,
+  green: number,
+  blue: number,
+  timing: InputTiming,
+): number {
+  const normalizedSlot = clampPaletteSlotIndex(slotIndex);
+  const hsv = rgbToHsv(red, green, blue);
+  const hueRatio = hsv.hue <= 0 ? 0 : (360 - hsv.hue) / 360;
+  const hueSteps = Math.round(hueRatio * COLOR_PALETTE_EDITOR_HUE_STEP_COUNT);
+  const saturationSteps = scaleChannelToSteps(hsv.saturation, COLOR_PALETTE_EDITOR_SATURATION_STEP_COUNT);
+  const valueDropSteps = scaleChannelToSteps(1 - hsv.value, COLOR_PALETTE_EDITOR_VALUE_STEP_COUNT);
+  const generalPressMs = timing.buttonPressMs + timing.inputDelayMs;
+  const menuPressMs = COLOR_PALETTE_MENU_PRESS_DURATION_MS + COLOR_PALETTE_MENU_INPUT_DELAY_MS;
+
+  return (
+    generalPressMs + // open palette with Y
+    COLOR_PALETTE_MENU_OPEN_SETTLE_MS +
+    COLOR_PALETTE_RESET_TO_BOTTOM_STEPS * menuPressMs +
+    (COLOR_PALETTE_SLOT_COUNT - 1 - normalizedSlot) * menuPressMs +
+    menuPressMs + // enter slot with Y
+    COLOR_PALETTE_EDITOR_OPEN_SETTLE_MS +
+    menuPressMs + // switch to custom tab with R
+    BASIC_COLOR_TAB_SETTLE_MS +
+    (COLOR_PALETTE_EDITOR_RESET_UP_HOLD_MS + timing.inputDelayMs) +
+    (COLOR_PALETTE_EDITOR_RESET_LEFT_HOLD_MS + timing.inputDelayMs) +
+    (COLOR_PALETTE_EDITOR_HUE_RESET_HOLD_MS + timing.inputDelayMs) +
+    hueSteps * generalPressMs +
+    (saturationSteps > 0 ? saturationSteps * COLOR_PALETTE_EDITOR_MOVE_STEP_MS + timing.inputDelayMs : 0) +
+    (valueDropSteps > 0 ? valueDropSteps * COLOR_PALETTE_EDITOR_MOVE_STEP_MS + timing.inputDelayMs : 0) +
+    3 * generalPressMs + // B, A, B
+    timing.inputDelayMs +
+    PALETTE_CONFIG_TIMEOUT_MARGIN_MS
+  );
 }
 
 function isRecognizedDeviceLine(line: string): boolean {
@@ -266,7 +375,22 @@ export function getAckTimeoutForCommand(
   }
 
   if (trimmed.startsWith("PC ")) {
-    return Math.max(baseTimeoutMs, 20_000);
+    const match = /^PC\s+(-?\d+)\s+#([0-9a-f]{6})$/iu.exec(trimmed);
+
+    if (!match?.[1] || !match[2]) {
+      return Math.max(baseTimeoutMs, 20_000);
+    }
+
+    const slotIndex = Number.parseInt(match[1], 10);
+    const hex = match[2];
+    const red = Number.parseInt(hex.slice(0, 2), 16);
+    const green = Number.parseInt(hex.slice(2, 4), 16);
+    const blue = Number.parseInt(hex.slice(4, 6), 16);
+
+    return Math.max(
+      baseTimeoutMs,
+      estimatePaletteConfigDurationMs(slotIndex, red, green, blue, timing),
+    );
   }
 
   return baseTimeoutMs;

--- a/apps/desktop/test/three-layer-fix.test.ts
+++ b/apps/desktop/test/three-layer-fix.test.ts
@@ -200,6 +200,14 @@ test("dynamic timeouts follow CFG INPUT timing", () => {
   assert.equal(getAckTimeoutForCommand("H", 500, timing), 4700);
 });
 
+test("palette-config commands get enough timeout for calibrated custom colors", () => {
+  const timing = { buttonPressMs: 100, inputDelayMs: 100, homeMs: 1800 };
+
+  assert.equal(getAckTimeoutForCommand("PC 1 #4E3239", 20_000, timing), 20_440);
+  assert.equal(getAckTimeoutForCommand("PC 2 #00FF00", 20_000, timing), 46_340);
+  assert.equal(getAckTimeoutForCommand("PC 6 #000000", 20_000, timing), 20_000);
+});
+
 test("controller input report failures are not retried", async () => {
   const lines: string[] = [];
   const sender = new SimulatedAckSender();


### PR DESCRIPTION
## Summary

- Re-enabled the experimental custom multi-color mode in the web UI
- Added full preview of all quantized colors used by the current image
- Added raw `STICK <X> <Y> <MS>` command for custom-color calibration
- Calibrated custom palette editor reset behavior and HSV mapping
- Switched custom-color editor flow to the `R` tab before adjustment
- Updated custom-color timing constants to the current tested values
- Fixed `PC <slot> <#RRGGBB>` ACK timeout by using dynamic timeout estimation
- Updated development notes for the current custom multi-color workflow

## Known limitations

- Still experimental and open-loop
- Desktop ACK timeout math duplicates firmware-side timing constants
- `STICK` parsing still needs stricter numeric validation
