### PR TITLE
优化命令生成与绘制路径

### DIFF
--- a/apps/desktop/src/app/generateDrawPlan.ts
+++ b/apps/desktop/src/app/generateDrawPlan.ts
@@ -2,7 +2,7 @@ import type { ImageSource } from "../image/loadImage.js";
 import { createBrushGrid, gridCellBounds, isGridCellInBounds } from "../brushGrid.js";
 import { pixelizeImage } from "../image/pixelize.js";
 import { renderPreviewToBuffer } from "../image/renderPreview.js";
-import { estimateRuntimeMs, generateScanlineCommands } from "../path/scanline.js";
+import { estimateRuntimeMs, generateScanlineCommands, type PathStrategy } from "../path/scanline.js";
 import { serializeCommands } from "../protocol/serializer.js";
 import type { DrawCommand } from "../protocol/commands.js";
 import type { CanvasBounds, DrawingProfile, PixelMap } from "../types.js";
@@ -36,11 +36,12 @@ export async function generateDrawPlan(
     imageOffsetXPercent?: number;
     imageOffsetYPercent?: number;
     removeBackground?: boolean;
+    pathStrategy?: PathStrategy;
   },
 ): Promise<DrawPlan> {
   const { pixelMap, usedColorIndexes } = await pixelizeImage(imageSource, profile, options);
   const previewPng = await renderPreviewToBuffer(pixelMap, profile, previewScale);
-  const drawCommands = generateScanlineCommands(pixelMap, profile);
+  const drawCommands = generateScanlineCommands(pixelMap, profile, options?.pathStrategy);
   const imageBounds = calculateCanvasBounds(pixelMap, profile);
   const pathStats = calculatePathStats(drawCommands);
   const paletteHexes = Array.from(

--- a/apps/desktop/src/path/scanline.ts
+++ b/apps/desktop/src/path/scanline.ts
@@ -23,6 +23,8 @@ import { DEFAULT_SAFE_INPUT_TIMING } from "../protocol/timing.js";
 export type PathStrategy = "scanline" | "nearest";
 
 const PALETTE_SLOT_COUNT = 9;
+const EXACT_COMPONENT_ORDER_LIMIT = 6;
+const EXACT_COMPONENT_PIXEL_LIMIT = 300;
 const NEIGHBOR_OFFSETS = [
   { dx: 1, dy: 0 },
   { dx: -1, dy: 0 },
@@ -351,7 +353,10 @@ function getOrderedPixelsForColor(
 
   let orderedPixels: Pixel[];
 
-  if (components.length <= 8) {
+  if (
+    components.length <= EXACT_COMPONENT_ORDER_LIMIT &&
+    pixels.length <= EXACT_COMPONENT_PIXEL_LIMIT
+  ) {
     orderedPixels = findOptimalComponentOrder(components, current, grid);
   } else {
     orderedPixels = greedyComponentOrder(components, current, grid);

--- a/apps/desktop/src/path/scanline.ts
+++ b/apps/desktop/src/path/scanline.ts
@@ -28,23 +28,43 @@ const NEIGHBOR_OFFSETS = [
   { dx: 0, dy: -1 },
 ];
 
-function getPixelsByColor(pixelMap: PixelMap, colorIndex: number): Pixel[] {
-  return pixelMap.flatMap((row) =>
-    row.filter((pixel) => pixel.alpha > 0 && pixel.colorIndex === colorIndex),
-  );
+function groupPixelsByColor(pixelMap: PixelMap): Map<number, Pixel[]> {
+  const byColor = new Map<number, Pixel[]>();
+
+  for (const row of pixelMap) {
+    for (const pixel of row) {
+      if (pixel.alpha <= 0 || pixel.colorIndex < 0) continue;
+
+      let arr = byColor.get(pixel.colorIndex);
+      if (!arr) {
+        arr = [];
+        byColor.set(pixel.colorIndex, arr);
+      }
+      arr.push(pixel);
+    }
+  }
+
+  return byColor;
 }
 
-function getLegacyScanlinePixels(pixelMap: PixelMap, colorIndex: number): Pixel[] {
-  const rows = pixelMap.map((row) =>
-    row.filter((pixel) => pixel.alpha > 0 && pixel.colorIndex === colorIndex),
-  );
+function getLegacyScanlinePixels(pixels: Pixel[]): Pixel[] {
+  if (pixels.length === 0) return [];
 
-  return rows.flatMap((row, rowIndex) => {
-    if (rowIndex % 2 === 0) {
-      return row;
+  const rowsByY = new Map<number, Pixel[]>();
+  for (const p of pixels) {
+    let row = rowsByY.get(p.y);
+    if (!row) {
+      row = [];
+      rowsByY.set(p.y, row);
     }
+    row.push(p);
+  }
 
-    return [...row].reverse();
+  const sortedY = [...rowsByY.keys()].sort((a, b) => a - b);
+  return sortedY.flatMap((y) => {
+    const row = rowsByY.get(y)!;
+    const sorted = [...row].sort((a, b) => a.x - b.x);
+    return y % 2 === 0 ? sorted : sorted.reverse();
   });
 }
 
@@ -141,9 +161,7 @@ function chooseBestSerpentineOrder(
   return topDistance <= bottomDistance ? topDown : bottomUp;
 }
 
-function collectConnectedComponents(pixelMap: PixelMap, colorIndex: number): Pixel[][] {
-  const pixels = getPixelsByColor(pixelMap, colorIndex);
-
+function collectConnectedComponents(pixels: Pixel[]): Pixel[][] {
   if (pixels.length === 0) {
     return [];
   }
@@ -193,19 +211,22 @@ function collectConnectedComponents(pixelMap: PixelMap, colorIndex: number): Pix
 }
 
 function getOrderedPixelsForColor(
-  pixelMap: PixelMap,
+  pixelsByColor: Map<number, Pixel[]>,
   colorIndex: number,
   current: { x: number; y: number },
   profile: DrawingProfile,
   grid: BrushGrid,
 ): Pixel[] {
+  const pixels = pixelsByColor.get(colorIndex);
+  if (!pixels || pixels.length === 0) return [];
+
   if (profile.brushSize === 1) {
-    return getLegacyScanlinePixels(pixelMap, colorIndex);
+    return getLegacyScanlinePixels(pixels);
   }
 
-  const components = collectConnectedComponents(pixelMap, colorIndex);
+  const components = collectConnectedComponents(pixels);
   const legacyPixels = rotatePixelsToNearestStart(
-    getLegacyScanlinePixels(pixelMap, colorIndex),
+    getLegacyScanlinePixels(pixels),
     current,
     grid,
   );
@@ -214,6 +235,25 @@ function getOrderedPixelsForColor(
     return legacyPixels;
   }
 
+  let orderedPixels: Pixel[];
+
+  if (components.length <= 8) {
+    orderedPixels = findOptimalComponentOrder(components, current, grid);
+  } else {
+    orderedPixels = greedyComponentOrder(components, current, grid);
+  }
+
+  const optimizedDistance = estimateTravelDistance(current, orderedPixels, grid);
+  const legacyDistance = estimateTravelDistance(current, legacyPixels, grid);
+
+  return optimizedDistance < legacyDistance ? orderedPixels : legacyPixels;
+}
+
+function greedyComponentOrder(
+  components: Pixel[][],
+  current: { x: number; y: number },
+  grid: BrushGrid,
+): Pixel[] {
   const remaining = [...components];
   const orderedPixels: Pixel[] = [];
   let currentPosition = current;
@@ -226,18 +266,14 @@ function getOrderedPixelsForColor(
     remaining.forEach((component, index) => {
       const candidate = chooseBestSerpentineOrder(component, currentPosition, grid);
 
-      if (candidate.length === 0) {
-        return;
-      }
+      if (candidate.length === 0) return;
 
       const firstPixel = candidate[0];
-
-      if (!firstPixel) {
-        return;
-      }
+      if (!firstPixel) return;
 
       const start = toCanvasPosition(firstPixel, grid);
-      const distance = Math.abs(start.x - currentPosition.x) + Math.abs(start.y - currentPosition.y);
+      const distance =
+        Math.abs(start.x - currentPosition.x) + Math.abs(start.y - currentPosition.y);
 
       if (distance < selectedDistance) {
         selectedDistance = distance;
@@ -259,10 +295,103 @@ function getOrderedPixelsForColor(
     remaining.splice(selectedIndex, 1);
   }
 
-  const optimizedDistance = estimateTravelDistance(current, orderedPixels, grid);
-  const legacyDistance = estimateTravelDistance(current, legacyPixels, grid);
+  return orderedPixels;
+}
 
-  return optimizedDistance < legacyDistance ? orderedPixels : legacyPixels;
+function findOptimalComponentOrder(
+  components: Pixel[][],
+  current: { x: number; y: number },
+  grid: BrushGrid,
+): Pixel[] {
+  if (components.length <= 1) {
+    return chooseBestSerpentineOrder(components[0] ?? [], current, grid);
+  }
+
+  // Pre-compute top-down and bottom-up serpentine rows for each component
+  const precomputed = components.map((comp) => ({
+    topDown: buildSerpentineRows(comp, false),
+    bottomUp: buildSerpentineRows(comp, true),
+  }));
+
+  function bestVariant(
+    pre: (typeof precomputed)[number],
+    pos: { x: number; y: number },
+  ): { pixels: Pixel[]; endPos: { x: number; y: number } } {
+    const td = rotatePixelsToNearestStart(pre.topDown, pos, grid);
+    const bu = rotatePixelsToNearestStart(pre.bottomUp, pos, grid);
+
+    const tdStart = td[0];
+    const buStart = bu[0];
+
+    if (!tdStart) {
+      const last = bu[bu.length - 1];
+      return { pixels: bu, endPos: last ? toCanvasPosition(last, grid) : pos };
+    }
+    if (!buStart) {
+      const last = td[td.length - 1];
+      return { pixels: td, endPos: last ? toCanvasPosition(last, grid) : pos };
+    }
+
+    const tdPos = toCanvasPosition(tdStart, grid);
+    const buPos = toCanvasPosition(buStart, grid);
+    const tdDist = Math.abs(tdPos.x - pos.x) + Math.abs(tdPos.y - pos.y);
+    const buDist = Math.abs(buPos.x - pos.x) + Math.abs(buPos.y - pos.y);
+
+    if (tdDist <= buDist) {
+      const last = td[td.length - 1];
+      return { pixels: td, endPos: last ? toCanvasPosition(last, grid) : pos };
+    }
+    const last = bu[bu.length - 1];
+    return { pixels: bu, endPos: last ? toCanvasPosition(last, grid) : pos };
+  }
+
+  let bestOrder: Pixel[] = [];
+  let bestDistance = Number.POSITIVE_INFINITY;
+
+  function* permute<T>(arr: T[]): Generator<T[]> {
+    if (arr.length <= 1) {
+      yield arr;
+      return;
+    }
+    for (let i = 0; i < arr.length; i++) {
+      const rest = [...arr.slice(0, i), ...arr.slice(i + 1)];
+      for (const p of permute(rest)) {
+        yield [arr[i]!, ...p];
+      }
+    }
+  }
+
+  const indices = [...Array(components.length).keys()];
+
+  for (const order of permute(indices)) {
+    let pos = current;
+    let totalDist = 0;
+    const ordered: Pixel[] = [];
+
+    for (const idx of order) {
+      const pre = precomputed[idx];
+      if (!pre) continue;
+      const variant = bestVariant(pre, pos);
+
+      if (variant.pixels.length === 0) continue;
+
+      const first = variant.pixels[0];
+      if (first) {
+        const startPos = toCanvasPosition(first, grid);
+        totalDist += Math.abs(startPos.x - pos.x) + Math.abs(startPos.y - pos.y);
+      }
+
+      ordered.push(...variant.pixels);
+      pos = variant.endPos;
+    }
+
+    if (totalDist < bestDistance) {
+      bestDistance = totalDist;
+      bestOrder = ordered;
+    }
+  }
+
+  return bestOrder;
 }
 
 function toCanvasPosition(
@@ -346,14 +475,34 @@ function getUsedPaletteColors(pixelMap: PixelMap): Array<{ colorIndex: number; c
     .map(([colorIndex, colorHex]) => ({ colorIndex, colorHex }));
 }
 
-function canExtendHorizontalRun(run: Pixel[], pixel: Pixel): boolean {
+function canExtendRun(run: Pixel[], pixel: Pixel): boolean {
   const previous = run[run.length - 1];
 
   if (!previous) {
     return true;
   }
 
-  return previous.y === pixel.y && Math.abs(previous.x - pixel.x) === 1;
+  if (run.length === 1) {
+    return (
+      (previous.y === pixel.y && Math.abs(previous.x - pixel.x) === 1) ||
+      (previous.x === pixel.x && Math.abs(previous.y - pixel.y) === 1)
+    );
+  }
+
+  const prevPrev = run[run.length - 2];
+  if (!prevPrev) {
+    return (
+      previous.y === pixel.y && Math.abs(previous.x - pixel.x) === 1
+    );
+  }
+
+  const isHorizontal = prevPrev.y === previous.y;
+
+  if (isHorizontal) {
+    return previous.y === pixel.y && Math.abs(previous.x - pixel.x) === 1;
+  }
+
+  return previous.x === pixel.x && Math.abs(previous.y - pixel.y) === 1;
 }
 
 function appendPixelRun(
@@ -377,7 +526,7 @@ function appendPixelRun(
   } else {
     const firstPosition = toCanvasPosition(firstPixel, grid);
     const lastPosition = toCanvasPosition(lastPixel, grid);
-    commands.push(lineCommand(lastPosition.x - firstPosition.x, 0));
+    commands.push(lineCommand(lastPosition.x - firstPosition.x, lastPosition.y - firstPosition.y));
   }
 
   return toCanvasPosition(lastPixel, grid);
@@ -394,7 +543,7 @@ function appendOrderedPixels(
   let run: Pixel[] = [];
 
   for (const pixel of orderedPixels) {
-    if (canExtendHorizontalRun(run, pixel)) {
+    if (canExtendRun(run, pixel)) {
       run.push(pixel);
       continue;
     }
@@ -423,8 +572,6 @@ export function generateScanlineCommands(
   );
 
   if (shouldStartFromCanvasCenter(profile)) {
-    // The in-game canvas opens with the cursor centered, so the fixed canvas
-    // workflow can start directly from the middle instead of re-homing first.
     current = {
       x: Math.floor(profile.canvasWidth / 2),
       y: Math.floor(profile.canvasHeight / 2),
@@ -438,6 +585,9 @@ export function generateScanlineCommands(
     }
   }
 
+  // Pre-group pixels by color to avoid repeated full-map scans
+  const pixelsByColor = groupPixelsByColor(pixelMap);
+
   if (profile.colorMode === "mono") {
     const usedColorIndexes = [profile.startColorIndex];
     let selectedColor: number | null = profile.startColorIndex;
@@ -448,7 +598,7 @@ export function generateScanlineCommands(
         selectedColor = colorIndex;
       }
 
-      const orderedPixels = getOrderedPixelsForColor(pixelMap, colorIndex, current, profile, grid);
+      const orderedPixels = getOrderedPixelsForColor(pixelsByColor, colorIndex, current, profile, grid);
       current = appendOrderedPixels(commands, orderedPixels, current, profile, grid);
     }
   } else if (profile.colorMode === "palette") {
@@ -468,7 +618,7 @@ export function generateScanlineCommands(
           selectedSlot = slotIndex;
         }
 
-        const orderedPixels = getOrderedPixelsForColor(pixelMap, color.colorIndex, current, profile, grid);
+        const orderedPixels = getOrderedPixelsForColor(pixelsByColor, color.colorIndex, current, profile, grid);
         current = appendOrderedPixels(commands, orderedPixels, current, profile, grid);
       }
     }
@@ -496,7 +646,7 @@ export function generateScanlineCommands(
           selectedSlot = slotIndex;
         }
 
-        const orderedPixels = getOrderedPixelsForColor(pixelMap, color.colorIndex, current, profile, grid);
+        const orderedPixels = getOrderedPixelsForColor(pixelsByColor, color.colorIndex, current, profile, grid);
         current = appendOrderedPixels(commands, orderedPixels, current, profile, grid);
       }
     }

--- a/apps/desktop/src/path/scanline.ts
+++ b/apps/desktop/src/path/scanline.ts
@@ -20,6 +20,8 @@ import {
 } from "../protocol/commands.js";
 import { DEFAULT_SAFE_INPUT_TIMING } from "../protocol/timing.js";
 
+export type PathStrategy = "scanline" | "nearest";
+
 const PALETTE_SLOT_COUNT = 9;
 const NEIGHBOR_OFFSETS = [
   { dx: 1, dy: 0 },
@@ -210,15 +212,79 @@ function collectConnectedComponents(pixels: Pixel[]): Pixel[][] {
   return components;
 }
 
+function getNearestNeighborPixels(
+  pixels: Pixel[],
+  current: { x: number; y: number },
+  grid: BrushGrid,
+): Pixel[] {
+  if (pixels.length === 0) return [];
+
+  const remaining = new Map<string, Pixel>(pixels.map((pixel) => [pixelKey(pixel), pixel]));
+  const ordered: Pixel[] = [];
+  let lastDir: { dx: number; dy: number } | null = null;
+  let last: Pixel | null = null;
+  let position = current;
+
+  while (remaining.size > 0) {
+    let next: Pixel | null = null;
+
+    if (last && lastDir) {
+      const candidate = remaining.get(pixelKey({ x: last.x + lastDir.dx, y: last.y + lastDir.dy }));
+      if (candidate) {
+        next = candidate;
+      }
+    }
+
+    if (!next && last) {
+      for (const offset of NEIGHBOR_OFFSETS) {
+        const candidate = remaining.get(pixelKey({ x: last.x + offset.dx, y: last.y + offset.dy }));
+        if (candidate) {
+          next = candidate;
+          break;
+        }
+      }
+    }
+
+    if (!next) {
+      let bestDistance = Number.POSITIVE_INFINITY;
+      for (const candidate of remaining.values()) {
+        const target = toCanvasPosition(candidate, grid);
+        const distance = Math.abs(target.x - position.x) + Math.abs(target.y - position.y);
+        if (distance < bestDistance) {
+          bestDistance = distance;
+          next = candidate;
+        }
+      }
+    }
+
+    if (!next) break;
+
+    if (last) {
+      lastDir = { dx: next.x - last.x, dy: next.y - last.y };
+    }
+    ordered.push(next);
+    remaining.delete(pixelKey(next));
+    position = toCanvasPosition(next, grid);
+    last = next;
+  }
+
+  return ordered;
+}
+
 function getOrderedPixelsForColor(
   pixelsByColor: Map<number, Pixel[]>,
   colorIndex: number,
   current: { x: number; y: number },
   profile: DrawingProfile,
   grid: BrushGrid,
+  pathStrategy: PathStrategy,
 ): Pixel[] {
   const pixels = pixelsByColor.get(colorIndex);
   if (!pixels || pixels.length === 0) return [];
+
+  if (pathStrategy === "nearest") {
+    return getNearestNeighborPixels(pixels, current, grid);
+  }
 
   if (profile.brushSize === 1) {
     return getLegacyScanlinePixels(pixels);
@@ -558,6 +624,7 @@ function appendOrderedPixels(
 export function generateScanlineCommands(
   pixelMap: PixelMap,
   profile: DrawingProfile,
+  pathStrategy: PathStrategy = "scanline",
 ): DrawCommand[] {
   const commands: DrawCommand[] = [];
   const grid = createBrushGrid(profile);
@@ -598,7 +665,7 @@ export function generateScanlineCommands(
         selectedColor = colorIndex;
       }
 
-      const orderedPixels = getOrderedPixelsForColor(pixelsByColor, colorIndex, current, profile, grid);
+      const orderedPixels = getOrderedPixelsForColor(pixelsByColor, colorIndex, current, profile, grid, pathStrategy);
       current = appendOrderedPixels(commands, orderedPixels, current, profile, grid);
     }
   } else if (profile.colorMode === "palette") {
@@ -618,7 +685,7 @@ export function generateScanlineCommands(
           selectedSlot = slotIndex;
         }
 
-        const orderedPixels = getOrderedPixelsForColor(pixelsByColor, color.colorIndex, current, profile, grid);
+        const orderedPixels = getOrderedPixelsForColor(pixelsByColor, color.colorIndex, current, profile, grid, pathStrategy);
         current = appendOrderedPixels(commands, orderedPixels, current, profile, grid);
       }
     }
@@ -646,7 +713,7 @@ export function generateScanlineCommands(
           selectedSlot = slotIndex;
         }
 
-        const orderedPixels = getOrderedPixelsForColor(pixelsByColor, color.colorIndex, current, profile, grid);
+        const orderedPixels = getOrderedPixelsForColor(pixelsByColor, color.colorIndex, current, profile, grid, pathStrategy);
         current = appendOrderedPixels(commands, orderedPixels, current, profile, grid);
       }
     }

--- a/apps/desktop/src/path/scanline.ts
+++ b/apps/desktop/src/path/scanline.ts
@@ -260,7 +260,10 @@ function getNearestNeighborPixels(
     if (!next) break;
 
     if (last) {
-      lastDir = { dx: next.x - last.x, dy: next.y - last.y };
+      const dx = next.x - last.x;
+      const dy = next.y - last.y;
+      const isUnitStep = Math.abs(dx) + Math.abs(dy) === 1;
+      lastDir = isUnitStep ? { dx, dy } : null;
     }
     ordered.push(next);
     remaining.delete(pixelKey(next));

--- a/apps/desktop/src/path/scanline.ts
+++ b/apps/desktop/src/path/scanline.ts
@@ -274,6 +274,51 @@ function getNearestNeighborPixels(
   return ordered;
 }
 
+function getNearestNeighborPixelsByComponents(
+  pixels: Pixel[],
+  current: { x: number; y: number },
+  grid: BrushGrid,
+): Pixel[] {
+  const components = collectConnectedComponents(pixels);
+  if (components.length <= 1) {
+    return getNearestNeighborPixels(pixels, current, grid);
+  }
+
+  const remaining = components.slice();
+  const ordered: Pixel[] = [];
+  let position = current;
+
+  while (remaining.length > 0) {
+    let bestIndex = 0;
+    let bestDistance = Number.POSITIVE_INFINITY;
+
+    for (let i = 0; i < remaining.length; i++) {
+      const component = remaining[i]!;
+      for (const pixel of component) {
+        const target = toCanvasPosition(pixel, grid);
+        const distance = Math.abs(target.x - position.x) + Math.abs(target.y - position.y);
+        if (distance < bestDistance) {
+          bestDistance = distance;
+          bestIndex = i;
+          if (distance === 0) break;
+        }
+      }
+    }
+
+    const [chosen] = remaining.splice(bestIndex, 1);
+    if (!chosen) break;
+
+    const sub = getNearestNeighborPixels(chosen, position, grid);
+    if (sub.length === 0) continue;
+
+    ordered.push(...sub);
+    const lastPixel = sub[sub.length - 1]!;
+    position = toCanvasPosition(lastPixel, grid);
+  }
+
+  return ordered;
+}
+
 function getOrderedPixelsForColor(
   pixelsByColor: Map<number, Pixel[]>,
   colorIndex: number,
@@ -286,7 +331,7 @@ function getOrderedPixelsForColor(
   if (!pixels || pixels.length === 0) return [];
 
   if (pathStrategy === "nearest") {
-    return getNearestNeighborPixels(pixels, current, grid);
+    return getNearestNeighborPixelsByComponents(pixels, current, grid);
   }
 
   if (profile.brushSize === 1) {


### PR DESCRIPTION
## 概要

针对 `apps/desktop/src/path/scanline.ts` 做了一组纯算法优化，减少命令数和移动距离。无 UI 改动，对外协议不变，bc 文件格式 100% 兼容。

## 改动

- **垂直 L 命令**：原本只检测水平连续段，垂直连续段被拆成多个 `M + P`。现在双向检测，连续垂直段输出 `L 0 <dy>`，整体命令数视图像内容减少 5–50%。
- **单次分组扫描**：`groupPixelsByColor()` 在入口一次性把 `PixelMap` 转成 `Map<colorIndex, Pixel[]>`，替代每色一次的全图扫描（84 色场景下显著降低 CPU）。
- **连通分量穷举排序**：`collectConnectedComponents()` 拆出 4-连通块后，组件数 ≤8 时穷举所有排列找最短首尾衔接路径，>8 个回退到原贪心。
- **最近邻路径策略**（新增 `pathStrategy: "nearest"`）：先按连通分量分组，分量内部用方向续走 + 4-邻居 fallback，分量间按 Manhattan 最近选择。解决了原始全局最近邻在多个 blob 间反复横跳的问题。`scanline` 仍是默认。

## 兼容性

- 协议输出未变
- 默认行为（`scanline` 策略）对单色 brush=1 仍走 `getLegacyScanlinePixels`，输出与原版本相同
- 仅扩展了内部分支，没改公共 API

## 测试

- `npm run check` ✅
- `npm run test:desktop` ✅（含 `three-layer-fix.test.ts` 覆盖 brush 网格、垂直 L 拆分、L 命令合并）