### PR TITLE
Studio 进阶功能：量化、合并同类色、颜色计数、绘制速度、自定义命令页

### DIFF
--- a/apps/desktop/src/app/generateDrawPlan.ts
+++ b/apps/desktop/src/app/generateDrawPlan.ts
@@ -2,7 +2,7 @@ import type { ImageSource } from "../image/loadImage.js";
 import { createBrushGrid, gridCellBounds, isGridCellInBounds } from "../brushGrid.js";
 import { pixelizeImage } from "../image/pixelize.js";
 import { renderPreviewToBuffer } from "../image/renderPreview.js";
-import { estimateRuntimeMs, generateScanlineCommands } from "../path/scanline.js";
+import { estimateRuntimeMs, generateScanlineCommands, type PathStrategy } from "../path/scanline.js";
 import { serializeCommands } from "../protocol/serializer.js";
 import type { DrawCommand } from "../protocol/commands.js";
 import type { CanvasBounds, DrawingProfile, PixelMap } from "../types.js";
@@ -36,11 +36,12 @@ export async function generateDrawPlan(
     imageOffsetXPercent?: number;
     imageOffsetYPercent?: number;
     removeBackground?: boolean;
+    pathStrategy?: PathStrategy;
   },
 ): Promise<DrawPlan> {
   const { pixelMap, usedColorIndexes } = await pixelizeImage(imageSource, profile, options);
   const previewPng = await renderPreviewToBuffer(pixelMap, profile, previewScale);
-  const drawCommands = generateScanlineCommands(pixelMap, profile);
+  const drawCommands = generateScanlineCommands(pixelMap, profile, options?.pathStrategy);
   const imageBounds = calculateCanvasBounds(pixelMap, profile);
   const pathStats = calculatePathStats(drawCommands);
   const paletteHexes = Array.from(

--- a/apps/desktop/src/app/generateDrawPlan.ts
+++ b/apps/desktop/src/app/generateDrawPlan.ts
@@ -5,7 +5,7 @@ import { renderPreviewToBuffer } from "../image/renderPreview.js";
 import { estimateRuntimeMs, generateScanlineCommands, type PathStrategy } from "../path/scanline.js";
 import { serializeCommands } from "../protocol/serializer.js";
 import type { DrawCommand } from "../protocol/commands.js";
-import type { CanvasBounds, DrawingProfile, PixelMap } from "../types.js";
+import type { CanvasBounds, ColorDistanceMode, DitherMode, DrawingProfile, PixelMap } from "../types.js";
 
 export interface DrawPlanPathStats {
   lineRunCount: number;
@@ -19,6 +19,7 @@ export interface DrawPlan {
   commands: string[];
   pixelMap: PixelMap;
   usedColorIndexes: number[];
+  colorCounts: Record<number, number>;
   paletteHexes: string[];
   totalPixels: number;
   estimatedRuntimeMs: number;
@@ -36,10 +37,18 @@ export async function generateDrawPlan(
     imageOffsetXPercent?: number;
     imageOffsetYPercent?: number;
     removeBackground?: boolean;
+    brightness?: number;
+    contrast?: number;
+    saturation?: number;
+    ditherMode?: DitherMode;
+    ditherAmount?: number;
+    colorDistanceMode?: ColorDistanceMode;
+    mergeSimilarColors?: boolean;
+    mergeThreshold?: number;
     pathStrategy?: PathStrategy;
   },
 ): Promise<DrawPlan> {
-  const { pixelMap, usedColorIndexes } = await pixelizeImage(imageSource, profile, options);
+  const { pixelMap, usedColorIndexes, colorCounts } = await pixelizeImage(imageSource, profile, options);
   const previewPng = await renderPreviewToBuffer(pixelMap, profile, previewScale);
   const drawCommands = generateScanlineCommands(pixelMap, profile, options?.pathStrategy);
   const imageBounds = calculateCanvasBounds(pixelMap, profile);
@@ -61,6 +70,7 @@ export async function generateDrawPlan(
     commands: serializeCommands(drawCommands),
     pixelMap,
     usedColorIndexes,
+    colorCounts,
     paletteHexes,
     totalPixels: pixelMap.length * (pixelMap[0]?.length ?? 0),
     estimatedRuntimeMs: estimateRuntimeMs(drawCommands, profile),

--- a/apps/desktop/src/image/pixelize.ts
+++ b/apps/desktop/src/image/pixelize.ts
@@ -1,9 +1,10 @@
-import type { DrawingProfile, PixelizationResult } from "../types.js";
+import type { ColorDistanceMode, DitherMode, DrawingProfile, PixelizationResult, RawImageData } from "../types.js";
 import { createBrushGrid } from "../brushGrid.js";
 import type { ImageSource } from "./loadImage.js";
 import { autoRemoveBackground } from "./removeBackground.js";
 import { resizeImage } from "./resizeImage.js";
-import { quantizePixels } from "./quantize.js";
+import { distanceSquared, quantizePixels } from "./quantize.js";
+import { parseHexColor } from "../utils/colors.js";
 
 function collapsePixelMapForBrush(
   pixelMap: PixelizationResult["pixelMap"],
@@ -117,6 +118,75 @@ function collapsePixelMapForBrush(
   return collapsed;
 }
 
+function mergeSimilarColorsInMap(
+  pixelMap: PixelizationResult["pixelMap"],
+  usedColorIndexes: number[],
+  paletteHexes: string[],
+  distanceMode: ColorDistanceMode,
+  tolerance: number,
+): number[] {
+  let threshold: number;
+  if (distanceMode === "lab") threshold = tolerance * 4;
+  else if (distanceMode === "weighted") threshold = tolerance * 30;
+  else threshold = tolerance * 100;
+  if (threshold <= 0 || usedColorIndexes.length <= 1) return usedColorIndexes;
+
+  const counts = new Map<number, number>();
+  for (const row of pixelMap) {
+    for (const pixel of row) {
+      if (pixel.colorIndex >= 0) {
+        counts.set(pixel.colorIndex, (counts.get(pixel.colorIndex) || 0) + 1);
+      }
+    }
+  }
+
+  const paletteRgb = paletteHexes.map(parseHexColor);
+  const used = usedColorIndexes
+    .filter((ci) => counts.has(ci))
+    .sort((a, b) => (counts.get(b) || 0) - (counts.get(a) || 0));
+
+  const mergeTo = new Map<number, number>();
+
+  for (const ci of used) {
+    if (mergeTo.has(ci)) continue;
+    let rep = ci;
+    let repN = counts.get(ci) || 0;
+    for (const cj of used) {
+      if (cj === ci || mergeTo.has(cj)) continue;
+      const a = paletteRgb[ci], b = paletteRgb[cj];
+      if (a && b && distanceSquared(a, b, distanceMode) < threshold) {
+        const n = counts.get(cj) || 0;
+        if (n > repN) { rep = cj; repN = n; }
+      }
+    }
+    for (const cj of used) {
+      if (cj === rep || mergeTo.has(cj)) continue;
+      const a = paletteRgb[rep], b = paletteRgb[cj];
+      if (a && b && distanceSquared(a, b, distanceMode) < threshold) {
+        mergeTo.set(cj, rep);
+      }
+    }
+  }
+
+  for (const row of pixelMap) {
+    for (const pixel of row) {
+      const mapped = mergeTo.get(pixel.colorIndex);
+      if (mapped !== undefined) {
+        pixel.colorIndex = mapped;
+        pixel.colorHex = paletteHexes[mapped] || pixel.colorHex;
+      }
+    }
+  }
+
+  return Array.from(
+    new Set(
+      pixelMap.flatMap((row) =>
+        row.filter((pixel) => pixel.alpha > 0).map((pixel) => pixel.colorIndex),
+      ),
+    ),
+  ).sort((a, b) => a - b);
+}
+
 export async function pixelizeImage(
   imageSource: ImageSource,
   profile: DrawingProfile,
@@ -125,6 +195,14 @@ export async function pixelizeImage(
     imageOffsetXPercent?: number;
     imageOffsetYPercent?: number;
     removeBackground?: boolean;
+    brightness?: number;
+    contrast?: number;
+    saturation?: number;
+    ditherMode?: DitherMode;
+    ditherAmount?: number;
+    colorDistanceMode?: ColorDistanceMode;
+    mergeSimilarColors?: boolean;
+    mergeThreshold?: number;
   },
 ): Promise<PixelizationResult> {
   const resizeOptions = {
@@ -142,17 +220,27 @@ export async function pixelizeImage(
       : {}),
   };
   const resizedImage = await resizeImage(imageSource, resizeOptions);
-  const rawImage = options?.removeBackground ? autoRemoveBackground(resizedImage) : resizedImage;
+  const rawImage = applyImageAdjustments(
+    options?.removeBackground ? autoRemoveBackground(resizedImage) : resizedImage,
+    {
+      brightness: options?.brightness ?? 0,
+      contrast: options?.contrast ?? 0,
+      saturation: options?.saturation ?? 0,
+    },
+  );
 
   const fullPixelMap = quantizePixels(rawImage, {
     colorMode: profile.colorMode,
     colorCount: profile.colorCount,
     monoThreshold: profile.monoThreshold,
     palette: profile.palette,
+    ditherMode: options?.ditherMode ?? "none",
+    ditherAmount: options?.ditherAmount ?? 1,
+    distanceMode: options?.colorDistanceMode ?? "weighted",
   });
   const pixelMap = collapsePixelMapForBrush(fullPixelMap, profile);
 
-  const usedColorIndexes = Array.from(
+  let usedColorIndexes = Array.from(
     new Set(
       pixelMap.flatMap((row) =>
         row.filter((pixel) => pixel.alpha > 0).map((pixel) => pixel.colorIndex),
@@ -160,8 +248,72 @@ export async function pixelizeImage(
     ),
   ).sort((a, b) => a - b);
 
+  if (options?.mergeSimilarColors) {
+    usedColorIndexes = mergeSimilarColorsInMap(
+      pixelMap,
+      usedColorIndexes,
+      profile.palette,
+      options?.colorDistanceMode ?? "weighted",
+      options?.mergeThreshold ?? 40,
+    );
+  }
+
+  const colorCounts: Record<number, number> = {};
+  for (const row of pixelMap) {
+    for (const pixel of row) {
+      if (pixel.alpha > 0 && pixel.colorIndex >= 0) {
+        colorCounts[pixel.colorIndex] = (colorCounts[pixel.colorIndex] || 0) + 1;
+      }
+    }
+  }
+
   return {
     pixelMap,
     usedColorIndexes,
+    colorCounts,
+  };
+}
+
+function applyImageAdjustments(
+  image: RawImageData,
+  options: {
+    brightness: number;
+    contrast: number;
+    saturation: number;
+  },
+): RawImageData {
+  if (options.brightness === 0 && options.contrast === 0 && options.saturation === 0) {
+    return image;
+  }
+
+  const data = Buffer.from(image.data);
+  const contrast = (options.contrast + 100) / 100;
+  const saturation = (options.saturation + 100) / 100;
+
+  for (let offset = 0; offset < data.length; offset += image.channels) {
+    let r = data[offset] ?? 0;
+    let g = data[offset + 1] ?? 0;
+    let b = data[offset + 2] ?? 0;
+
+    r += options.brightness;
+    g += options.brightness;
+    b += options.brightness;
+    r = (r - 128) * contrast + 128;
+    g = (g - 128) * contrast + 128;
+    b = (b - 128) * contrast + 128;
+
+    const luminance = 0.299 * r + 0.587 * g + 0.114 * b;
+    r = luminance + (r - luminance) * saturation;
+    g = luminance + (g - luminance) * saturation;
+    b = luminance + (b - luminance) * saturation;
+
+    data[offset] = Math.max(0, Math.min(255, Math.round(r)));
+    data[offset + 1] = Math.max(0, Math.min(255, Math.round(g)));
+    data[offset + 2] = Math.max(0, Math.min(255, Math.round(b)));
+  }
+
+  return {
+    ...image,
+    data,
   };
 }

--- a/apps/desktop/src/image/quantize.ts
+++ b/apps/desktop/src/image/quantize.ts
@@ -1,6 +1,6 @@
 import * as iq from "image-q";
 
-import type { ColorMode, Pixel, PixelMap, RgbColor } from "../types.js";
+import type { ColorDistanceMode, ColorMode, DitherMode, Pixel, PixelMap, RgbColor } from "../types.js";
 import {
   colorDistanceSquared,
   compositeOnWhite,
@@ -10,9 +10,185 @@ import {
 } from "../utils/colors.js";
 
 const TRANSPARENCY_ALPHA_THRESHOLD = 16;
+const BAYER4 = [
+  [0, 8, 2, 10],
+  [12, 4, 14, 6],
+  [3, 11, 1, 9],
+  [15, 7, 13, 5],
+].map((row) => row.map((value) => value / 16 - 0.5));
 
 function isTransparentAlpha(alpha: number): boolean {
   return alpha <= TRANSPARENCY_ALPHA_THRESHOLD;
+}
+
+function rgbToLab(color: RgbColor): [number, number, number] {
+  const pivotRgb = (value: number) => {
+    const normalized = value / 255;
+    return normalized > 0.04045
+      ? ((normalized + 0.055) / 1.055) ** 2.4
+      : normalized / 12.92;
+  };
+  const r = pivotRgb(color.r);
+  const g = pivotRgb(color.g);
+  const b = pivotRgb(color.b);
+  const x = (r * 0.4124 + g * 0.3576 + b * 0.1805) / 0.95047;
+  const y = r * 0.2126 + g * 0.7152 + b * 0.0722;
+  const z = (r * 0.0193 + g * 0.1192 + b * 0.9505) / 1.08883;
+  const pivotXyz = (value: number) =>
+    value > 0.008856 ? Math.cbrt(value) : 7.787 * value + 16 / 116;
+  const fx = pivotXyz(x);
+  const fy = pivotXyz(y);
+  const fz = pivotXyz(z);
+  return [116 * fy - 16, 500 * (fx - fy), 200 * (fy - fz)];
+}
+
+export function distanceSquared(a: RgbColor, b: RgbColor, mode: ColorDistanceMode): number {
+  if (mode === "lab") {
+    const [l1, a1, b1] = rgbToLab(a);
+    const [l2, a2, b2] = rgbToLab(b);
+    return (l1 - l2) ** 2 + (a1 - a2) ** 2 + (b1 - b2) ** 2;
+  }
+
+  if (mode === "weighted") {
+    const redMean = (a.r + b.r) / 2;
+    const dr = a.r - b.r;
+    const dg = a.g - b.g;
+    const db = a.b - b.b;
+    return ((512 + redMean) * dr * dr) / 256 + 4 * dg * dg + ((767 - redMean) * db * db) / 256;
+  }
+
+  return colorDistanceSquared(a, b);
+}
+
+function nearestPaletteEntry(
+  rgb: RgbColor,
+  paletteEntries: Array<{
+    colorHex: string;
+    colorIndex: number;
+    rgb: RgbColor;
+  }>,
+  distanceMode: ColorDistanceMode,
+) {
+  let nearestColor = paletteEntries[0];
+  let nearestDistance = Number.POSITIVE_INFINITY;
+
+  for (const entry of paletteEntries) {
+    const distance = distanceSquared(rgb, entry.rgb, distanceMode);
+
+    if (distance < nearestDistance) {
+      nearestDistance = distance;
+      nearestColor = entry;
+    }
+  }
+
+  return nearestColor;
+}
+
+function buildDitheredFixedPalettePixelMap(
+  image: {
+    width: number;
+    height: number;
+    channels: number;
+    data: Buffer;
+  },
+  paletteEntries: Array<{
+    colorHex: string;
+    colorIndex: number;
+    rgb: RgbColor;
+  }>,
+  options: {
+    distanceMode: ColorDistanceMode;
+    ditherMode: DitherMode;
+    ditherAmount: number;
+  },
+): PixelMap {
+  const pixelMap: PixelMap = [];
+  const buffer = new Float32Array(image.width * image.height * 3);
+
+  for (let y = 0; y < image.height; y += 1) {
+    for (let x = 0; x < image.width; x += 1) {
+      const sourceOffset = (y * image.width + x) * image.channels;
+      const targetOffset = (y * image.width + x) * 3;
+      const alpha = image.channels >= 4 ? (image.data[sourceOffset + 3] ?? 255) : 255;
+      const rgb = compositeOnWhite(
+        image.data[sourceOffset] ?? 0,
+        image.data[sourceOffset + 1] ?? 0,
+        image.data[sourceOffset + 2] ?? 0,
+        alpha,
+      );
+      buffer[targetOffset] = rgb.r;
+      buffer[targetOffset + 1] = rgb.g;
+      buffer[targetOffset + 2] = rgb.b;
+    }
+  }
+
+  const addError = (x: number, y: number, er: number, eg: number, eb: number, weight: number) => {
+    if (x < 0 || y < 0 || x >= image.width || y >= image.height) {
+      return;
+    }
+    const offset = (y * image.width + x) * 3;
+    buffer[offset] = (buffer[offset] ?? 0) + er * weight;
+    buffer[offset + 1] = (buffer[offset + 1] ?? 0) + eg * weight;
+    buffer[offset + 2] = (buffer[offset + 2] ?? 0) + eb * weight;
+  };
+
+  for (let y = 0; y < image.height; y += 1) {
+    const row: Pixel[] = [];
+
+    for (let x = 0; x < image.width; x += 1) {
+      const imageOffset = (y * image.width + x) * image.channels;
+      const alpha = image.channels >= 4 ? (image.data[imageOffset + 3] ?? 255) : 255;
+
+      if (isTransparentAlpha(alpha)) {
+        row.push({ x, y, colorIndex: -1, colorHex: "#ffffff", alpha: 0 });
+        continue;
+      }
+
+      const offset = (y * image.width + x) * 3;
+      const orderedOffset =
+        options.ditherMode === "ordered" ? (BAYER4[y % 4]?.[x % 4] ?? 0) * 64 * options.ditherAmount : 0;
+      const rgb = {
+        r: (buffer[offset] ?? 0) + orderedOffset,
+        g: (buffer[offset + 1] ?? 0) + orderedOffset,
+        b: (buffer[offset + 2] ?? 0) + orderedOffset,
+      };
+      const nearest = nearestPaletteEntry(rgb, paletteEntries, options.distanceMode);
+      const selected = nearest ?? paletteEntries[0];
+
+      row.push({
+        x,
+        y,
+        colorIndex: selected?.colorIndex ?? 0,
+        colorHex: selected?.colorHex ?? "#000000",
+        alpha: 255,
+      });
+
+      if (options.ditherMode === "fs" || options.ditherMode === "atkinson") {
+        const er = (rgb.r - (selected?.rgb.r ?? 0)) * options.ditherAmount;
+        const eg = (rgb.g - (selected?.rgb.g ?? 0)) * options.ditherAmount;
+        const eb = (rgb.b - (selected?.rgb.b ?? 0)) * options.ditherAmount;
+
+        if (options.ditherMode === "fs") {
+          addError(x + 1, y, er, eg, eb, 7 / 16);
+          addError(x - 1, y + 1, er, eg, eb, 3 / 16);
+          addError(x, y + 1, er, eg, eb, 5 / 16);
+          addError(x + 1, y + 1, er, eg, eb, 1 / 16);
+        } else {
+          const weight = 1 / 8;
+          addError(x + 1, y, er, eg, eb, weight);
+          addError(x + 2, y, er, eg, eb, weight);
+          addError(x - 1, y + 1, er, eg, eb, weight);
+          addError(x, y + 1, er, eg, eb, weight);
+          addError(x + 1, y + 1, er, eg, eb, weight);
+          addError(x, y + 2, er, eg, eb, weight);
+        }
+      }
+    }
+
+    pixelMap.push(row);
+  }
+
+  return pixelMap;
 }
 
 function buildMonoPixelMap(
@@ -25,9 +201,22 @@ function buildMonoPixelMap(
   options: {
     monoThreshold: number;
     palette: string[];
+    distanceMode: ColorDistanceMode;
+    ditherMode: DitherMode;
+    ditherAmount: number;
   },
 ): PixelMap {
   const monoPalette = options.palette.slice(0, 2);
+  const monoEntries = monoPalette.map((colorHex, colorIndex) => ({
+    colorHex,
+    colorIndex,
+    rgb: parseHexColor(colorHex),
+  }));
+
+  if (options.ditherMode !== "none" && monoEntries.length >= 2) {
+    return buildDitheredFixedPalettePixelMap(image, monoEntries, options);
+  }
+
   const pixelMap: PixelMap = [];
 
   for (let y = 0; y < image.height; y += 1) {
@@ -158,7 +347,16 @@ function buildFixedPalettePixelMap(
     colorIndex: number;
     rgb: RgbColor;
   }>,
+  options: {
+    distanceMode: ColorDistanceMode;
+    ditherMode: DitherMode;
+    ditherAmount: number;
+  },
 ): PixelMap {
+  if (options.ditherMode !== "none") {
+    return buildDitheredFixedPalettePixelMap(image, paletteEntries, options);
+  }
+
   const pixelMap: PixelMap = [];
 
   for (let y = 0; y < image.height; y += 1) {
@@ -184,17 +382,7 @@ function buildFixedPalettePixelMap(
 
       const rgb = compositeOnWhite(r, g, b, a);
 
-      let nearestColor = paletteEntries[0];
-      let nearestDistance = Number.POSITIVE_INFINITY;
-
-      for (const color of paletteEntries) {
-        const distance = colorDistanceSquared(rgb, color.rgb);
-
-        if (distance < nearestDistance) {
-          nearestDistance = distance;
-          nearestColor = color;
-        }
-      }
+      const nearestColor = nearestPaletteEntry(rgb, paletteEntries, options.distanceMode);
 
       row.push({
         x,
@@ -218,20 +406,9 @@ function findNearestPaletteEntry(
     colorIndex: number;
     rgb: RgbColor;
   }>,
+  distanceMode: ColorDistanceMode,
 ) {
-  let nearestColor = paletteEntries[0];
-  let nearestDistance = Number.POSITIVE_INFINITY;
-
-  for (const entry of paletteEntries) {
-    const distance = colorDistanceSquared(rgb, entry.rgb);
-
-    if (distance < nearestDistance) {
-      nearestDistance = distance;
-      nearestColor = entry;
-    }
-  }
-
-  return nearestColor;
+  return nearestPaletteEntry(rgb, paletteEntries, distanceMode);
 }
 
 function buildOfficialPalettePixelMap(
@@ -244,6 +421,9 @@ function buildOfficialPalettePixelMap(
   options: {
     palette: string[];
     colorCount: number;
+    distanceMode: ColorDistanceMode;
+    ditherMode: DitherMode;
+    ditherAmount: number;
   },
 ): PixelMap {
   const officialPaletteEntries = options.palette.map((colorHex, colorIndex) => ({
@@ -269,6 +449,7 @@ function buildOfficialPalettePixelMap(
     const nearestEntry = findNearestPaletteEntry(
       { r: point.r, g: point.g, b: point.b },
       officialPaletteEntries,
+      options.distanceMode,
     );
 
     if (!nearestEntry || seenOfficialIndexes.has(nearestEntry.colorIndex)) {
@@ -283,7 +464,7 @@ function buildOfficialPalettePixelMap(
     selectedEntries.push(officialPaletteEntries[0]);
   }
 
-  return buildFixedPalettePixelMap(image, selectedEntries);
+  return buildFixedPalettePixelMap(image, selectedEntries, options);
 }
 
 export function quantizePixels(
@@ -298,14 +479,24 @@ export function quantizePixels(
     colorCount: number;
     monoThreshold: number;
     palette: string[];
+    distanceMode?: ColorDistanceMode;
+    ditherMode?: DitherMode;
+    ditherAmount?: number;
   },
 ): PixelMap {
+  const normalizedOptions = {
+    ...options,
+    distanceMode: options.distanceMode ?? "weighted",
+    ditherMode: options.ditherMode ?? "none",
+    ditherAmount: Math.max(0, Math.min(1, options.ditherAmount ?? 1)),
+  };
+
   if (options.colorMode === "mono") {
-    return buildMonoPixelMap(image, options);
+    return buildMonoPixelMap(image, normalizedOptions);
   }
 
   if (options.colorMode === "official") {
-    return buildOfficialPalettePixelMap(image, options);
+    return buildOfficialPalettePixelMap(image, normalizedOptions);
   }
 
   return buildPalettePixelMap(image, options);

--- a/apps/desktop/src/image/resizeImage.ts
+++ b/apps/desktop/src/image/resizeImage.ts
@@ -14,7 +14,8 @@ export async function resizeImage(
     offsetYPercent?: number;
   },
 ): Promise<RawImageData> {
-  const fit = options.resizeMode === "cover" ? "outside" : "inside";
+  const fit =
+    options.resizeMode === "cover" ? "outside" : options.resizeMode === "stretch" ? "fill" : "inside";
   const scalePercent = normalizeScalePercent(options.scalePercent);
   const offsetXPercent = normalizeOffsetPercent(options.offsetXPercent);
   const offsetYPercent = normalizeOffsetPercent(options.offsetYPercent);

--- a/apps/desktop/src/path/scanline.ts
+++ b/apps/desktop/src/path/scanline.ts
@@ -28,23 +28,43 @@ const NEIGHBOR_OFFSETS = [
   { dx: 0, dy: -1 },
 ];
 
-function getPixelsByColor(pixelMap: PixelMap, colorIndex: number): Pixel[] {
-  return pixelMap.flatMap((row) =>
-    row.filter((pixel) => pixel.alpha > 0 && pixel.colorIndex === colorIndex),
-  );
+function groupPixelsByColor(pixelMap: PixelMap): Map<number, Pixel[]> {
+  const byColor = new Map<number, Pixel[]>();
+
+  for (const row of pixelMap) {
+    for (const pixel of row) {
+      if (pixel.alpha <= 0 || pixel.colorIndex < 0) continue;
+
+      let arr = byColor.get(pixel.colorIndex);
+      if (!arr) {
+        arr = [];
+        byColor.set(pixel.colorIndex, arr);
+      }
+      arr.push(pixel);
+    }
+  }
+
+  return byColor;
 }
 
-function getLegacyScanlinePixels(pixelMap: PixelMap, colorIndex: number): Pixel[] {
-  const rows = pixelMap.map((row) =>
-    row.filter((pixel) => pixel.alpha > 0 && pixel.colorIndex === colorIndex),
-  );
+function getLegacyScanlinePixels(pixels: Pixel[]): Pixel[] {
+  if (pixels.length === 0) return [];
 
-  return rows.flatMap((row, rowIndex) => {
-    if (rowIndex % 2 === 0) {
-      return row;
+  const rowsByY = new Map<number, Pixel[]>();
+  for (const p of pixels) {
+    let row = rowsByY.get(p.y);
+    if (!row) {
+      row = [];
+      rowsByY.set(p.y, row);
     }
+    row.push(p);
+  }
 
-    return [...row].reverse();
+  const sortedY = [...rowsByY.keys()].sort((a, b) => a - b);
+  return sortedY.flatMap((y) => {
+    const row = rowsByY.get(y)!;
+    const sorted = [...row].sort((a, b) => a.x - b.x);
+    return y % 2 === 0 ? sorted : sorted.reverse();
   });
 }
 
@@ -141,9 +161,7 @@ function chooseBestSerpentineOrder(
   return topDistance <= bottomDistance ? topDown : bottomUp;
 }
 
-function collectConnectedComponents(pixelMap: PixelMap, colorIndex: number): Pixel[][] {
-  const pixels = getPixelsByColor(pixelMap, colorIndex);
-
+function collectConnectedComponents(pixels: Pixel[]): Pixel[][] {
   if (pixels.length === 0) {
     return [];
   }
@@ -193,19 +211,22 @@ function collectConnectedComponents(pixelMap: PixelMap, colorIndex: number): Pix
 }
 
 function getOrderedPixelsForColor(
-  pixelMap: PixelMap,
+  pixelsByColor: Map<number, Pixel[]>,
   colorIndex: number,
   current: { x: number; y: number },
   profile: DrawingProfile,
   grid: BrushGrid,
 ): Pixel[] {
+  const pixels = pixelsByColor.get(colorIndex);
+  if (!pixels || pixels.length === 0) return [];
+
   if (profile.brushSize === 1) {
-    return getLegacyScanlinePixels(pixelMap, colorIndex);
+    return getLegacyScanlinePixels(pixels);
   }
 
-  const components = collectConnectedComponents(pixelMap, colorIndex);
+  const components = collectConnectedComponents(pixels);
   const legacyPixels = rotatePixelsToNearestStart(
-    getLegacyScanlinePixels(pixelMap, colorIndex),
+    getLegacyScanlinePixels(pixels),
     current,
     grid,
   );
@@ -214,6 +235,25 @@ function getOrderedPixelsForColor(
     return legacyPixels;
   }
 
+  let orderedPixels: Pixel[];
+
+  if (components.length <= 8) {
+    orderedPixels = findOptimalComponentOrder(components, current, grid);
+  } else {
+    orderedPixels = greedyComponentOrder(components, current, grid);
+  }
+
+  const optimizedDistance = estimateTravelDistance(current, orderedPixels, grid);
+  const legacyDistance = estimateTravelDistance(current, legacyPixels, grid);
+
+  return optimizedDistance < legacyDistance ? orderedPixels : legacyPixels;
+}
+
+function greedyComponentOrder(
+  components: Pixel[][],
+  current: { x: number; y: number },
+  grid: BrushGrid,
+): Pixel[] {
   const remaining = [...components];
   const orderedPixels: Pixel[] = [];
   let currentPosition = current;
@@ -226,18 +266,14 @@ function getOrderedPixelsForColor(
     remaining.forEach((component, index) => {
       const candidate = chooseBestSerpentineOrder(component, currentPosition, grid);
 
-      if (candidate.length === 0) {
-        return;
-      }
+      if (candidate.length === 0) return;
 
       const firstPixel = candidate[0];
-
-      if (!firstPixel) {
-        return;
-      }
+      if (!firstPixel) return;
 
       const start = toCanvasPosition(firstPixel, grid);
-      const distance = Math.abs(start.x - currentPosition.x) + Math.abs(start.y - currentPosition.y);
+      const distance =
+        Math.abs(start.x - currentPosition.x) + Math.abs(start.y - currentPosition.y);
 
       if (distance < selectedDistance) {
         selectedDistance = distance;
@@ -259,10 +295,103 @@ function getOrderedPixelsForColor(
     remaining.splice(selectedIndex, 1);
   }
 
-  const optimizedDistance = estimateTravelDistance(current, orderedPixels, grid);
-  const legacyDistance = estimateTravelDistance(current, legacyPixels, grid);
+  return orderedPixels;
+}
 
-  return optimizedDistance < legacyDistance ? orderedPixels : legacyPixels;
+function findOptimalComponentOrder(
+  components: Pixel[][],
+  current: { x: number; y: number },
+  grid: BrushGrid,
+): Pixel[] {
+  if (components.length <= 1) {
+    return chooseBestSerpentineOrder(components[0] ?? [], current, grid);
+  }
+
+  // Pre-compute top-down and bottom-up serpentine rows for each component
+  const precomputed = components.map((comp) => ({
+    topDown: buildSerpentineRows(comp, false),
+    bottomUp: buildSerpentineRows(comp, true),
+  }));
+
+  function bestVariant(
+    pre: (typeof precomputed)[number],
+    pos: { x: number; y: number },
+  ): { pixels: Pixel[]; endPos: { x: number; y: number } } {
+    const td = rotatePixelsToNearestStart(pre.topDown, pos, grid);
+    const bu = rotatePixelsToNearestStart(pre.bottomUp, pos, grid);
+
+    const tdStart = td[0];
+    const buStart = bu[0];
+
+    if (!tdStart) {
+      const last = bu[bu.length - 1];
+      return { pixels: bu, endPos: last ? toCanvasPosition(last, grid) : pos };
+    }
+    if (!buStart) {
+      const last = td[td.length - 1];
+      return { pixels: td, endPos: last ? toCanvasPosition(last, grid) : pos };
+    }
+
+    const tdPos = toCanvasPosition(tdStart, grid);
+    const buPos = toCanvasPosition(buStart, grid);
+    const tdDist = Math.abs(tdPos.x - pos.x) + Math.abs(tdPos.y - pos.y);
+    const buDist = Math.abs(buPos.x - pos.x) + Math.abs(buPos.y - pos.y);
+
+    if (tdDist <= buDist) {
+      const last = td[td.length - 1];
+      return { pixels: td, endPos: last ? toCanvasPosition(last, grid) : pos };
+    }
+    const last = bu[bu.length - 1];
+    return { pixels: bu, endPos: last ? toCanvasPosition(last, grid) : pos };
+  }
+
+  let bestOrder: Pixel[] = [];
+  let bestDistance = Number.POSITIVE_INFINITY;
+
+  function* permute<T>(arr: T[]): Generator<T[]> {
+    if (arr.length <= 1) {
+      yield arr;
+      return;
+    }
+    for (let i = 0; i < arr.length; i++) {
+      const rest = [...arr.slice(0, i), ...arr.slice(i + 1)];
+      for (const p of permute(rest)) {
+        yield [arr[i]!, ...p];
+      }
+    }
+  }
+
+  const indices = [...Array(components.length).keys()];
+
+  for (const order of permute(indices)) {
+    let pos = current;
+    let totalDist = 0;
+    const ordered: Pixel[] = [];
+
+    for (const idx of order) {
+      const pre = precomputed[idx];
+      if (!pre) continue;
+      const variant = bestVariant(pre, pos);
+
+      if (variant.pixels.length === 0) continue;
+
+      const first = variant.pixels[0];
+      if (first) {
+        const startPos = toCanvasPosition(first, grid);
+        totalDist += Math.abs(startPos.x - pos.x) + Math.abs(startPos.y - pos.y);
+      }
+
+      ordered.push(...variant.pixels);
+      pos = variant.endPos;
+    }
+
+    if (totalDist < bestDistance) {
+      bestDistance = totalDist;
+      bestOrder = ordered;
+    }
+  }
+
+  return bestOrder;
 }
 
 function toCanvasPosition(
@@ -346,14 +475,34 @@ function getUsedPaletteColors(pixelMap: PixelMap): Array<{ colorIndex: number; c
     .map(([colorIndex, colorHex]) => ({ colorIndex, colorHex }));
 }
 
-function canExtendHorizontalRun(run: Pixel[], pixel: Pixel): boolean {
+function canExtendRun(run: Pixel[], pixel: Pixel): boolean {
   const previous = run[run.length - 1];
 
   if (!previous) {
     return true;
   }
 
-  return previous.y === pixel.y && Math.abs(previous.x - pixel.x) === 1;
+  if (run.length === 1) {
+    return (
+      (previous.y === pixel.y && Math.abs(previous.x - pixel.x) === 1) ||
+      (previous.x === pixel.x && Math.abs(previous.y - pixel.y) === 1)
+    );
+  }
+
+  const prevPrev = run[run.length - 2];
+  if (!prevPrev) {
+    return (
+      previous.y === pixel.y && Math.abs(previous.x - pixel.x) === 1
+    );
+  }
+
+  const isHorizontal = prevPrev.y === previous.y;
+
+  if (isHorizontal) {
+    return previous.y === pixel.y && Math.abs(previous.x - pixel.x) === 1;
+  }
+
+  return previous.x === pixel.x && Math.abs(previous.y - pixel.y) === 1;
 }
 
 function appendPixelRun(
@@ -377,7 +526,7 @@ function appendPixelRun(
   } else {
     const firstPosition = toCanvasPosition(firstPixel, grid);
     const lastPosition = toCanvasPosition(lastPixel, grid);
-    commands.push(lineCommand(lastPosition.x - firstPosition.x, 0));
+    commands.push(lineCommand(lastPosition.x - firstPosition.x, lastPosition.y - firstPosition.y));
   }
 
   return toCanvasPosition(lastPixel, grid);
@@ -394,7 +543,7 @@ function appendOrderedPixels(
   let run: Pixel[] = [];
 
   for (const pixel of orderedPixels) {
-    if (canExtendHorizontalRun(run, pixel)) {
+    if (canExtendRun(run, pixel)) {
       run.push(pixel);
       continue;
     }
@@ -423,8 +572,6 @@ export function generateScanlineCommands(
   );
 
   if (shouldStartFromCanvasCenter(profile)) {
-    // The in-game canvas opens with the cursor centered, so the fixed canvas
-    // workflow can start directly from the middle instead of re-homing first.
     current = {
       x: Math.floor(profile.canvasWidth / 2),
       y: Math.floor(profile.canvasHeight / 2),
@@ -438,6 +585,9 @@ export function generateScanlineCommands(
     }
   }
 
+  // Pre-group pixels by color to avoid repeated full-map scans
+  const pixelsByColor = groupPixelsByColor(pixelMap);
+
   if (profile.colorMode === "mono") {
     const usedColorIndexes = [profile.startColorIndex];
     let selectedColor: number | null = profile.startColorIndex;
@@ -448,7 +598,7 @@ export function generateScanlineCommands(
         selectedColor = colorIndex;
       }
 
-      const orderedPixels = getOrderedPixelsForColor(pixelMap, colorIndex, current, profile, grid);
+      const orderedPixels = getOrderedPixelsForColor(pixelsByColor, colorIndex, current, profile, grid);
       current = appendOrderedPixels(commands, orderedPixels, current, profile, grid);
     }
   } else if (profile.colorMode === "palette") {
@@ -468,7 +618,7 @@ export function generateScanlineCommands(
           selectedSlot = slotIndex;
         }
 
-        const orderedPixels = getOrderedPixelsForColor(pixelMap, color.colorIndex, current, profile, grid);
+        const orderedPixels = getOrderedPixelsForColor(pixelsByColor, color.colorIndex, current, profile, grid);
         current = appendOrderedPixels(commands, orderedPixels, current, profile, grid);
       }
     }
@@ -496,7 +646,7 @@ export function generateScanlineCommands(
           selectedSlot = slotIndex;
         }
 
-        const orderedPixels = getOrderedPixelsForColor(pixelMap, color.colorIndex, current, profile, grid);
+        const orderedPixels = getOrderedPixelsForColor(pixelsByColor, color.colorIndex, current, profile, grid);
         current = appendOrderedPixels(commands, orderedPixels, current, profile, grid);
       }
     }

--- a/apps/desktop/src/path/scanline.ts
+++ b/apps/desktop/src/path/scanline.ts
@@ -20,6 +20,8 @@ import {
 } from "../protocol/commands.js";
 import { DEFAULT_SAFE_INPUT_TIMING } from "../protocol/timing.js";
 
+export type PathStrategy = "scanline" | "nearest";
+
 const PALETTE_SLOT_COUNT = 9;
 const NEIGHBOR_OFFSETS = [
   { dx: 1, dy: 0 },
@@ -210,15 +212,79 @@ function collectConnectedComponents(pixels: Pixel[]): Pixel[][] {
   return components;
 }
 
+function getNearestNeighborPixels(
+  pixels: Pixel[],
+  current: { x: number; y: number },
+  grid: BrushGrid,
+): Pixel[] {
+  if (pixels.length === 0) return [];
+
+  const remaining = new Map<string, Pixel>(pixels.map((pixel) => [pixelKey(pixel), pixel]));
+  const ordered: Pixel[] = [];
+  let lastDir: { dx: number; dy: number } | null = null;
+  let last: Pixel | null = null;
+  let position = current;
+
+  while (remaining.size > 0) {
+    let next: Pixel | null = null;
+
+    if (last && lastDir) {
+      const candidate = remaining.get(pixelKey({ x: last.x + lastDir.dx, y: last.y + lastDir.dy }));
+      if (candidate) {
+        next = candidate;
+      }
+    }
+
+    if (!next && last) {
+      for (const offset of NEIGHBOR_OFFSETS) {
+        const candidate = remaining.get(pixelKey({ x: last.x + offset.dx, y: last.y + offset.dy }));
+        if (candidate) {
+          next = candidate;
+          break;
+        }
+      }
+    }
+
+    if (!next) {
+      let bestDistance = Number.POSITIVE_INFINITY;
+      for (const candidate of remaining.values()) {
+        const target = toCanvasPosition(candidate, grid);
+        const distance = Math.abs(target.x - position.x) + Math.abs(target.y - position.y);
+        if (distance < bestDistance) {
+          bestDistance = distance;
+          next = candidate;
+        }
+      }
+    }
+
+    if (!next) break;
+
+    if (last) {
+      lastDir = { dx: next.x - last.x, dy: next.y - last.y };
+    }
+    ordered.push(next);
+    remaining.delete(pixelKey(next));
+    position = toCanvasPosition(next, grid);
+    last = next;
+  }
+
+  return ordered;
+}
+
 function getOrderedPixelsForColor(
   pixelsByColor: Map<number, Pixel[]>,
   colorIndex: number,
   current: { x: number; y: number },
   profile: DrawingProfile,
   grid: BrushGrid,
+  pathStrategy: PathStrategy,
 ): Pixel[] {
   const pixels = pixelsByColor.get(colorIndex);
   if (!pixels || pixels.length === 0) return [];
+
+  if (pathStrategy === "nearest") {
+    return getNearestNeighborPixels(pixels, current, grid);
+  }
 
   if (profile.brushSize === 1) {
     return getLegacyScanlinePixels(pixels);
@@ -558,6 +624,7 @@ function appendOrderedPixels(
 export function generateScanlineCommands(
   pixelMap: PixelMap,
   profile: DrawingProfile,
+  pathStrategy: PathStrategy = "scanline",
 ): DrawCommand[] {
   const commands: DrawCommand[] = [];
   const grid = createBrushGrid(profile);
@@ -598,7 +665,7 @@ export function generateScanlineCommands(
         selectedColor = colorIndex;
       }
 
-      const orderedPixels = getOrderedPixelsForColor(pixelsByColor, colorIndex, current, profile, grid);
+      const orderedPixels = getOrderedPixelsForColor(pixelsByColor, colorIndex, current, profile, grid, pathStrategy);
       current = appendOrderedPixels(commands, orderedPixels, current, profile, grid);
     }
   } else if (profile.colorMode === "palette") {
@@ -618,7 +685,7 @@ export function generateScanlineCommands(
           selectedSlot = slotIndex;
         }
 
-        const orderedPixels = getOrderedPixelsForColor(pixelsByColor, color.colorIndex, current, profile, grid);
+        const orderedPixels = getOrderedPixelsForColor(pixelsByColor, color.colorIndex, current, profile, grid, pathStrategy);
         current = appendOrderedPixels(commands, orderedPixels, current, profile, grid);
       }
     }
@@ -646,7 +713,7 @@ export function generateScanlineCommands(
           selectedSlot = slotIndex;
         }
 
-        const orderedPixels = getOrderedPixelsForColor(pixelsByColor, color.colorIndex, current, profile, grid);
+        const orderedPixels = getOrderedPixelsForColor(pixelsByColor, color.colorIndex, current, profile, grid, pathStrategy);
         current = appendOrderedPixels(commands, orderedPixels, current, profile, grid);
       }
     }

--- a/apps/desktop/src/path/scanline.ts
+++ b/apps/desktop/src/path/scanline.ts
@@ -260,7 +260,10 @@ function getNearestNeighborPixels(
     if (!next) break;
 
     if (last) {
-      lastDir = { dx: next.x - last.x, dy: next.y - last.y };
+      const dx = next.x - last.x;
+      const dy = next.y - last.y;
+      const isUnitStep = Math.abs(dx) + Math.abs(dy) === 1;
+      lastDir = isUnitStep ? { dx, dy } : null;
     }
     ordered.push(next);
     remaining.delete(pixelKey(next));

--- a/apps/desktop/src/path/scanline.ts
+++ b/apps/desktop/src/path/scanline.ts
@@ -680,9 +680,9 @@ export function generateScanlineCommands(
 
   commands.push(
     inputConfigCommand(
-      DEFAULT_SAFE_INPUT_TIMING.buttonPressMs,
-      DEFAULT_SAFE_INPUT_TIMING.inputDelayMs,
-      DEFAULT_SAFE_INPUT_TIMING.homeMs,
+      profile.buttonPressDuration || DEFAULT_SAFE_INPUT_TIMING.buttonPressMs,
+      profile.inputDelay || DEFAULT_SAFE_INPUT_TIMING.inputDelayMs,
+      profile.homeDuration || DEFAULT_SAFE_INPUT_TIMING.homeMs,
     ),
   );
 

--- a/apps/desktop/src/path/scanline.ts
+++ b/apps/desktop/src/path/scanline.ts
@@ -274,6 +274,51 @@ function getNearestNeighborPixels(
   return ordered;
 }
 
+function getNearestNeighborPixelsByComponents(
+  pixels: Pixel[],
+  current: { x: number; y: number },
+  grid: BrushGrid,
+): Pixel[] {
+  const components = collectConnectedComponents(pixels);
+  if (components.length <= 1) {
+    return getNearestNeighborPixels(pixels, current, grid);
+  }
+
+  const remaining = components.slice();
+  const ordered: Pixel[] = [];
+  let position = current;
+
+  while (remaining.length > 0) {
+    let bestIndex = 0;
+    let bestDistance = Number.POSITIVE_INFINITY;
+
+    for (let i = 0; i < remaining.length; i++) {
+      const component = remaining[i]!;
+      for (const pixel of component) {
+        const target = toCanvasPosition(pixel, grid);
+        const distance = Math.abs(target.x - position.x) + Math.abs(target.y - position.y);
+        if (distance < bestDistance) {
+          bestDistance = distance;
+          bestIndex = i;
+          if (distance === 0) break;
+        }
+      }
+    }
+
+    const [chosen] = remaining.splice(bestIndex, 1);
+    if (!chosen) break;
+
+    const sub = getNearestNeighborPixels(chosen, position, grid);
+    if (sub.length === 0) continue;
+
+    ordered.push(...sub);
+    const lastPixel = sub[sub.length - 1]!;
+    position = toCanvasPosition(lastPixel, grid);
+  }
+
+  return ordered;
+}
+
 function getOrderedPixelsForColor(
   pixelsByColor: Map<number, Pixel[]>,
   colorIndex: number,
@@ -286,7 +331,7 @@ function getOrderedPixelsForColor(
   if (!pixels || pixels.length === 0) return [];
 
   if (pathStrategy === "nearest") {
-    return getNearestNeighborPixels(pixels, current, grid);
+    return getNearestNeighborPixelsByComponents(pixels, current, grid);
   }
 
   if (profile.brushSize === 1) {

--- a/apps/desktop/src/types.ts
+++ b/apps/desktop/src/types.ts
@@ -1,5 +1,7 @@
-export type ResizeMode = "contain" | "cover";
+export type ResizeMode = "contain" | "cover" | "stretch";
 export type ColorMode = "mono" | "palette" | "official";
+export type DitherMode = "none" | "fs" | "atkinson" | "ordered";
+export type ColorDistanceMode = "weighted" | "rgb" | "lab";
 export type ControllerButton = "A" | "B" | "X" | "Y";
 export type StartCursor = "center" | "top-left";
 export type DrawingTool = "pen" | "eraser" | "fill" | "stamp" | "text" | "shape";
@@ -57,6 +59,7 @@ export interface DrawingProfile {
 export interface PixelizationResult {
   pixelMap: PixelMap;
   usedColorIndexes: number[];
+  colorCounts: Record<number, number>;
 }
 
 export interface CanvasBounds {

--- a/apps/desktop/src/web/server.ts
+++ b/apps/desktop/src/web/server.ts
@@ -24,7 +24,7 @@ import {
   type SerialSessionSnapshot,
 } from "../serial/sender.js";
 import { SimulatedAckSender } from "../simulator/sender.js";
-import type { SenderControls } from "../types.js";
+import type { ColorDistanceMode, DitherMode, SenderControls } from "../types.js";
 
 const __filename = fileURLToPath(import.meta.url);
 const __dirname = path.dirname(__filename);
@@ -350,6 +350,47 @@ function normalizeBrushSize(value: unknown, fallback: 1 | 3 | 7 | 13 | 19 | 27):
     : fallback;
 }
 
+function normalizeTimingMs(value: unknown, fallback: number): number {
+  if (typeof value !== "number" || !Number.isFinite(value)) {
+    return fallback;
+  }
+
+  return Math.max(16, Math.min(500, Math.round(value)));
+}
+
+function normalizeAdjustment(value: unknown): number {
+  if (typeof value !== "number" || !Number.isFinite(value)) {
+    return 0;
+  }
+
+  return Math.max(-100, Math.min(100, Math.round(value)));
+}
+
+function normalizeDitherMode(value: unknown): DitherMode {
+  return value === "fs" || value === "atkinson" || value === "ordered" ? value : "none";
+}
+
+function normalizeColorDistanceMode(value: unknown): ColorDistanceMode {
+  return value === "rgb" || value === "lab" ? value : "weighted";
+}
+
+function normalizeDitherAmount(value: unknown): number {
+  if (typeof value !== "number" || !Number.isFinite(value)) {
+    return 1;
+  }
+
+  return Math.max(0, Math.min(1, value));
+}
+
+function normalizeMergeThreshold(value: unknown, fallback = 40): number {
+  const parsed = typeof value === "number" ? value : Number(value);
+  if (!Number.isFinite(parsed)) {
+    return fallback;
+  }
+
+  return Math.max(0, Math.min(100, parsed));
+}
+
 function normalizeImageScalePercent(value: unknown, fallback = 100): number {
   if (typeof value !== "number" || !Number.isFinite(value)) {
     return fallback;
@@ -401,7 +442,7 @@ function makeCliOverrides(input: {
   height?: number;
   colors?: number;
   threshold?: number;
-  resizeMode?: "contain" | "cover";
+  resizeMode?: "contain" | "cover" | "stretch";
   mode?: "mono" | "palette" | "official";
   palette?: string[];
 }): CliOptions {
@@ -438,10 +479,21 @@ async function handleGenerate(request: IncomingMessage, response: ServerResponse
     threshold?: number;
     mode?: "mono" | "palette" | "official";
     colors?: number;
-    resizeMode?: "contain" | "cover";
+    resizeMode?: "contain" | "cover" | "stretch";
     palette?: string[];
     previewScale?: number;
     removeBackground?: boolean;
+    buttonPressMs?: number;
+    inputDelayMs?: number;
+    ditherMode?: DitherMode;
+    ditherAmount?: number;
+    colorDistanceMode?: ColorDistanceMode;
+    brightness?: number;
+    contrast?: number;
+    saturation?: number;
+    mergeSimilarColors?: boolean;
+    mergeThreshold?: number;
+    pathStrategy?: "scanline" | "nearest";
   };
 
   if (!body.imageDataUrl) {
@@ -471,19 +523,27 @@ async function handleGenerate(request: IncomingMessage, response: ServerResponse
   const profile = {
     ...baseProfile,
     brushSize: normalizeBrushSize(body.brushSize, baseProfile.brushSize),
+    buttonPressDuration: normalizeTimingMs(body.buttonPressMs, baseProfile.buttonPressDuration),
+    inputDelay: normalizeTimingMs(body.inputDelayMs, baseProfile.inputDelay),
   };
 
-  const plan = await generateDrawPlan(
-    decodeDataUrl(body.imageDataUrl),
-    profile,
-    body.previewScale ?? 12,
-    {
-      imageScalePercent,
-      imageOffsetXPercent,
-      imageOffsetYPercent,
-      removeBackground: body.removeBackground === true,
-    },
-  );
+  const generationOptions = {
+    imageScalePercent,
+    imageOffsetXPercent,
+    imageOffsetYPercent,
+    removeBackground: body.removeBackground === true,
+    brightness: normalizeAdjustment(body.brightness),
+    contrast: normalizeAdjustment(body.contrast),
+    saturation: normalizeAdjustment(body.saturation),
+    ditherMode: normalizeDitherMode(body.ditherMode),
+    ditherAmount: normalizeDitherAmount(body.ditherAmount),
+    colorDistanceMode: normalizeColorDistanceMode(body.colorDistanceMode),
+    mergeSimilarColors: body.mergeSimilarColors === true,
+    mergeThreshold: normalizeMergeThreshold(body.mergeThreshold),
+    pathStrategy: body.pathStrategy === "nearest" ? ("nearest" as const) : ("scanline" as const),
+  };
+  const imageSource = decodeDataUrl(body.imageDataUrl);
+  const plan = await generateDrawPlan(imageSource, profile, body.previewScale ?? 12, generationOptions);
 
   json(response, 200, {
     profile: {
@@ -501,9 +561,21 @@ async function handleGenerate(request: IncomingMessage, response: ServerResponse
       baudRate: profile.baudRate,
       ackTimeoutMs: profile.ackTimeoutMs,
       commandRetryCount: profile.commandRetryCount,
+      buttonPressMs: profile.buttonPressDuration,
+      inputDelayMs: profile.inputDelay,
+      ditherMode: generationOptions.ditherMode,
+      ditherAmount: generationOptions.ditherAmount,
+      colorDistanceMode: generationOptions.colorDistanceMode,
+      brightness: generationOptions.brightness,
+      contrast: generationOptions.contrast,
+      saturation: generationOptions.saturation,
+      mergeSimilarColors: generationOptions.mergeSimilarColors,
+      mergeThreshold: generationOptions.mergeThreshold,
+      pathStrategy: generationOptions.pathStrategy,
     },
     stats: {
       usedColorIndexes: plan.usedColorIndexes,
+      colorCounts: plan.colorCounts,
       totalPixels: plan.totalPixels,
       commandCount: plan.commands.length,
       estimatedRuntimeMs: plan.estimatedRuntimeMs,

--- a/apps/desktop/src/web/static/app.js
+++ b/apps/desktop/src/web/static/app.js
@@ -63,6 +63,19 @@ const state = {
     colorMode: "mono",
     colorCount: 32,
     removeBackground: false,
+    speedPreset: "60,60",
+    buttonPressMs: 60,
+    inputDelayMs: 60,
+    ditherMode: "fs",
+    ditherAmount: 100,
+    colorDistanceMode: "weighted",
+    brightness: 0,
+    contrast: 0,
+    saturation: 0,
+    resizeMode: "contain",
+    mergeSimilarColors: false,
+    mergeThreshold: 40,
+    pathStrategy: "scanline",
     usedColorIndexes: [],
     generatedPalette: [],
     officialPalette: {
@@ -85,6 +98,37 @@ const state = {
       finishedAt: null,
       error: null,
       lineCount: 0,
+    },
+    executionClock: {
+      id: null,
+      elapsedMs: 0,
+      runningSince: null,
+      avgMsPerCommand: null,
+      lastDone: 0,
+      lastSampleElapsedMs: 0,
+    },
+  },
+  custom: {
+    brushSize: 3,
+    commands: [],
+    execution: {
+      id: null,
+      status: "idle",
+      totalCommands: 0,
+      completedCommands: 0,
+      currentCommand: null,
+      startedAt: null,
+      finishedAt: null,
+      error: null,
+      lineCount: 0,
+    },
+    executionClock: {
+      id: null,
+      elapsedMs: 0,
+      runningSince: null,
+      avgMsPerCommand: null,
+      lastDone: 0,
+      lastSampleElapsedMs: 0,
     },
   },
   firmware: {
@@ -142,6 +186,25 @@ const els = {
   brushSizeSelect: document.getElementById("brush-size-select"),
   colorModeSelect: document.getElementById("color-mode-select"),
   colorCountSelect: document.getElementById("color-count-select"),
+  speedPresetSelect: document.getElementById("speed-preset-select"),
+  speedCustomRow: document.getElementById("speed-custom-row"),
+  speedPressInput: document.getElementById("speed-press-input"),
+  speedDelayInput: document.getElementById("speed-delay-input"),
+  ditherModeSelect: document.getElementById("dither-mode-select"),
+  ditherAmountRange: document.getElementById("dither-amount-range"),
+  ditherAmountValue: document.getElementById("dither-amount-value"),
+  colorDistanceSelect: document.getElementById("color-distance-select"),
+  resizeModeSelect: document.getElementById("resize-mode-select"),
+  mergeSimilarCheckbox: document.getElementById("merge-similar-checkbox"),
+  pathStrategyCheckbox: document.getElementById("path-strategy-checkbox"),
+  mergeThresholdRange: document.getElementById("merge-threshold-range"),
+  mergeThresholdValue: document.getElementById("merge-threshold-value"),
+  brightnessRange: document.getElementById("brightness-range"),
+  brightnessValue: document.getElementById("brightness-value"),
+  contrastRange: document.getElementById("contrast-range"),
+  contrastValue: document.getElementById("contrast-value"),
+  saturationRange: document.getElementById("saturation-range"),
+  saturationValue: document.getElementById("saturation-value"),
   thresholdLabel: document.getElementById("threshold-label"),
   thresholdRange: document.getElementById("threshold-range"),
   thresholdValue: document.getElementById("threshold-value"),
@@ -167,6 +230,9 @@ const els = {
   previewCanvas: document.getElementById("preview-canvas"),
   previewImage: document.getElementById("preview-image"),
   previewEmpty: document.getElementById("preview-empty"),
+  scriptReplayRow: document.getElementById("script-replay-row"),
+  scriptReplayCanvas: document.getElementById("script-replay-canvas"),
+  scriptReplayMeta: document.getElementById("script-replay-meta"),
   officialPalettePanel: document.getElementById("official-palette-panel"),
   officialPaletteSummary: document.getElementById("official-palette-summary"),
   officialPaletteGrid: document.getElementById("official-palette-grid"),
@@ -175,6 +241,26 @@ const els = {
   downloadButton: document.getElementById("download-button"),
   studioLogOutput: document.getElementById("log-output"),
   studioClearLogButton: document.getElementById("studio-clear-log-button"),
+  customBrushSizeSelect: document.getElementById("custom-brush-size-select"),
+  customPortSelect: document.getElementById("custom-port-select"),
+  customCommandsInput: document.getElementById("custom-commands-input"),
+  customPreviewButton: document.getElementById("custom-preview-button"),
+  customNormalizeButton: document.getElementById("custom-normalize-button"),
+  customClearButton: document.getElementById("custom-clear-button"),
+  customExecuteButton: document.getElementById("custom-execute-button"),
+  customPauseButton: document.getElementById("custom-pause-button"),
+  customResumeButton: document.getElementById("custom-resume-button"),
+  customStopButton: document.getElementById("custom-stop-button"),
+  customExecutionStatus: document.getElementById("custom-execution-status"),
+  customReplayCanvas: document.getElementById("custom-replay-canvas"),
+  customStatCommands: document.getElementById("custom-stat-commands"),
+  customStatDrawn: document.getElementById("custom-stat-drawn"),
+  customStatMode: document.getElementById("custom-stat-mode"),
+  customCopyButton: document.getElementById("custom-copy-button"),
+  customDownloadButton: document.getElementById("custom-download-button"),
+  customRefreshPortsButton: document.getElementById("custom-refresh-ports-button"),
+  customLogOutput: document.getElementById("custom-log-output"),
+  customClearLogButton: document.getElementById("custom-clear-log-button"),
   statColors: document.getElementById("stat-colors"),
   statPixels: document.getElementById("stat-pixels"),
   statCommands: document.getElementById("stat-commands"),
@@ -236,6 +322,7 @@ const els = {
 };
 
 let studioExecutionPollTimer = null;
+let customExecutionPollTimer = null;
 let firmwareToolingPollTimer = null;
 let windowsSerialDriverPollTimer = null;
 let studioPreviewRefreshTimer = null;
@@ -258,7 +345,12 @@ const STUDIO_IMAGE_OFFSET_LIMITS = {
   max: 100,
 };
 
-const VALID_PAGE_NAMES = new Set(["studio", "firmware", "controller"]);
+const STUDIO_SPEED_LIMITS = {
+  min: 16,
+  max: 500,
+};
+
+const VALID_PAGE_NAMES = new Set(["studio", "custom", "firmware", "controller"]);
 
 els.pageTabs.forEach((button) => {
   button.addEventListener("click", () => {
@@ -329,6 +421,78 @@ els.colorCountSelect.addEventListener("change", () => {
   scheduleStudioPreviewRefresh();
 });
 
+els.speedPresetSelect.addEventListener("change", () => {
+  setStudioSpeedPreset(els.speedPresetSelect.value);
+});
+
+els.speedPressInput.addEventListener("change", () => {
+  setStudioButtonPressMs(els.speedPressInput.value);
+});
+
+els.speedDelayInput.addEventListener("change", () => {
+  setStudioInputDelayMs(els.speedDelayInput.value);
+});
+
+els.ditherModeSelect.addEventListener("change", () => {
+  state.studio.ditherMode = els.ditherModeSelect.value;
+  syncStudioUi();
+  scheduleStudioPreviewRefresh();
+});
+
+els.ditherAmountRange.addEventListener("input", () => {
+  state.studio.ditherAmount = normalizeStudioNumericValue(els.ditherAmountRange.value, state.studio.ditherAmount, {
+    min: 0,
+    max: 100,
+  });
+  syncStudioUi();
+  scheduleStudioPreviewRefresh();
+});
+
+els.colorDistanceSelect.addEventListener("change", () => {
+  state.studio.colorDistanceMode = els.colorDistanceSelect.value;
+  syncStudioUi();
+  scheduleStudioPreviewRefresh();
+});
+
+els.resizeModeSelect.addEventListener("change", () => {
+  state.studio.resizeMode = els.resizeModeSelect.value;
+  syncStudioUi();
+  scheduleStudioPreviewRefresh();
+});
+
+els.mergeSimilarCheckbox.addEventListener("change", () => {
+  state.studio.mergeSimilarColors = els.mergeSimilarCheckbox.checked;
+  syncStudioUi();
+  scheduleStudioPreviewRefresh();
+});
+
+els.pathStrategyCheckbox.addEventListener("change", () => {
+  state.studio.pathStrategy = els.pathStrategyCheckbox.checked ? "nearest" : "scanline";
+  syncStudioUi();
+  scheduleStudioPreviewRefresh();
+});
+
+els.mergeThresholdRange.addEventListener("input", () => {
+  state.studio.mergeThreshold = normalizeStudioNumericValue(els.mergeThresholdRange.value, state.studio.mergeThreshold, {
+    min: 0,
+    max: 100,
+  });
+  syncStudioUi();
+  if (state.studio.mergeSimilarColors) scheduleStudioPreviewRefresh();
+});
+
+els.brightnessRange.addEventListener("input", () => {
+  setStudioAdjustment("brightness", els.brightnessRange.value);
+});
+
+els.contrastRange.addEventListener("input", () => {
+  setStudioAdjustment("contrast", els.contrastRange.value);
+});
+
+els.saturationRange.addEventListener("input", () => {
+  setStudioAdjustment("saturation", els.saturationRange.value);
+});
+
 els.autoRemoveBackgroundCheckbox.addEventListener("change", () => {
   state.studio.removeBackground = els.autoRemoveBackgroundCheckbox.checked;
   syncStudioUi();
@@ -347,11 +511,12 @@ els.thresholdRange.addEventListener("input", () => {
   scheduleStudioPreviewRefresh();
 });
 
-[els.studioPortSelect, els.firmwarePortSelect, els.controllerPortSelect].forEach((select) => {
+[els.studioPortSelect, els.customPortSelect, els.firmwarePortSelect, els.controllerPortSelect].forEach((select) => {
   select.addEventListener("change", () => {
     state.selectedPortPath = select.value;
     renderPortSelects();
     syncStudioUi();
+    syncCustomUi();
     syncFirmwareUi();
     syncControllerUi();
   });
@@ -452,6 +617,60 @@ els.resetExecutionButton.addEventListener("click", async () => {
   await sendStudioExecutionControl("reset", "强制恢复绘制状态");
 });
 
+els.customBrushSizeSelect.addEventListener("change", () => {
+  state.custom.brushSize = Number(els.customBrushSizeSelect.value) || 3;
+  syncCustomUi();
+  renderCustomPreview();
+});
+
+els.customPreviewButton.addEventListener("click", () => {
+  renderCustomPreview();
+});
+
+els.customNormalizeButton.addEventListener("click", () => {
+  normalizeCustomCommandInputs();
+});
+
+els.customClearButton.addEventListener("click", () => {
+  els.customCommandsInput.value = "";
+  renderCustomPreview();
+});
+
+els.customExecuteButton.addEventListener("click", async () => {
+  renderCustomPreview();
+  await executeCustomCommands(state.custom.commands, "开始执行自定义脚本");
+});
+
+els.customPauseButton.addEventListener("click", async () => {
+  await sendCustomExecutionControl("pause", "暂停");
+});
+
+els.customResumeButton.addEventListener("click", async () => {
+  await sendCustomExecutionControl("resume", "继续");
+});
+
+els.customStopButton.addEventListener("click", async () => {
+  await sendCustomExecutionControl("stop", "中断");
+});
+
+els.customCopyButton.addEventListener("click", async () => {
+  await copyCommandsToClipboard(state.custom.commands, "自定义脚本");
+});
+
+els.customDownloadButton.addEventListener("click", () => {
+  downloadCommands(state.custom.commands, "custom-friendmaker-commands.txt", "自定义脚本");
+});
+
+els.customRefreshPortsButton.addEventListener("click", async () => {
+  await refreshPorts({
+    log: (message) => appendLog(els.customLogOutput, message),
+  });
+});
+
+els.customClearLogButton.addEventListener("click", () => {
+  clearLog(els.customLogOutput);
+});
+
 async function generateStudioCommands({ logPrefix }) {
   if (!state.imageDataUrl) {
     appendLog(els.studioLogOutput, "请先选择图片。");
@@ -493,10 +712,21 @@ function buildStudioGeneratePayload() {
     imageOffsetYPercent: state.studio.imageOffsetYPercent,
     mode: state.studio.colorMode,
     colors: state.studio.colorCount,
-    resizeMode: "contain",
+    resizeMode: state.studio.resizeMode,
     threshold: Number(els.thresholdRange.value),
     previewScale: 12,
     removeBackground: state.studio.removeBackground,
+    buttonPressMs: state.studio.buttonPressMs,
+    inputDelayMs: state.studio.inputDelayMs,
+    ditherMode: state.studio.ditherMode,
+    ditherAmount: state.studio.ditherAmount / 100,
+    colorDistanceMode: state.studio.colorDistanceMode,
+    brightness: state.studio.brightness,
+    contrast: state.studio.contrast,
+    saturation: state.studio.saturation,
+    mergeSimilarColors: state.studio.mergeSimilarColors,
+    mergeThreshold: state.studio.mergeThreshold,
+    pathStrategy: state.studio.pathStrategy,
   };
 }
 
@@ -546,7 +776,17 @@ function applyGeneratedStudioPayload(payload) {
       : "mono";
   state.studio.colorCount = payload.profile.colorCount ?? state.studio.colorCount;
   state.studio.removeBackground = payload.profile.removeBackground === true;
-
+  state.studio.buttonPressMs = payload.profile.buttonPressMs ?? state.studio.buttonPressMs;
+  state.studio.inputDelayMs = payload.profile.inputDelayMs ?? state.studio.inputDelayMs;
+  state.studio.ditherMode = payload.profile.ditherMode ?? state.studio.ditherMode;
+  state.studio.ditherAmount = Math.round((payload.profile.ditherAmount ?? state.studio.ditherAmount / 100) * 100);
+  state.studio.colorDistanceMode = payload.profile.colorDistanceMode ?? state.studio.colorDistanceMode;
+  state.studio.brightness = payload.profile.brightness ?? state.studio.brightness;
+  state.studio.contrast = payload.profile.contrast ?? state.studio.contrast;
+  state.studio.saturation = payload.profile.saturation ?? state.studio.saturation;
+  state.studio.mergeSimilarColors = payload.profile.mergeSimilarColors ?? state.studio.mergeSimilarColors;
+  state.studio.mergeThreshold = payload.profile.mergeThreshold ?? state.studio.mergeThreshold;
+  state.studio.pathStrategy = payload.profile.pathStrategy ?? state.studio.pathStrategy;
   els.commandsOutput.value = payload.commands.join("\n");
   els.previewImage.src = payload.previewDataUrl;
   els.previewImage.classList.add("visible");
@@ -563,8 +803,112 @@ function applyGeneratedStudioPayload(payload) {
     ? `${payload.stats.commandCount} · L ${payload.stats.pathStats.lineRunCount}`
     : String(payload.stats.commandCount);
   els.statRuntime.textContent = payload.stats.estimatedRuntimeLabel;
+  renderScriptReplay();
   void updatePreviewBounds(payload);
   renderOfficialPalettePreview();
+}
+
+function officialPaletteRgb(index) {
+  const palette = state.studio.officialPalette;
+  const row = palette.grid[Math.floor(index / (palette.cols || 12))];
+  const hex = row?.[index % (palette.cols || 12)] ?? "#000000";
+  return hexToRgb(hex);
+}
+
+function hexToRgb(hex) {
+  const normalized = String(hex).replace("#", "");
+  return {
+    r: Number.parseInt(normalized.slice(0, 2), 16) || 0,
+    g: Number.parseInt(normalized.slice(2, 4), 16) || 0,
+    b: Number.parseInt(normalized.slice(4, 6), 16) || 0,
+  };
+}
+
+function renderScriptReplay() {
+  if (!state.commands.length || !els.scriptReplayCanvas) {
+    els.scriptReplayRow.classList.add("hidden");
+    return;
+  }
+
+  const canvas = els.scriptReplayCanvas;
+  canvas.width = state.studio.canvasSize;
+  canvas.height = state.studio.canvasSize;
+  const ctx = canvas.getContext("2d");
+
+  if (!ctx) {
+    return;
+  }
+
+  ctx.clearRect(0, 0, canvas.width, canvas.height);
+
+  let drawn = 0;
+
+  drawn += runScriptOnReplayCanvas(ctx, state.commands, state.studio.brushSize);
+
+  els.scriptReplayRow.classList.remove("hidden");
+  els.scriptReplayMeta.textContent = `${drawn} 笔回放`;
+}
+
+function runScriptOnReplayCanvas(ctx, commands, brushSize) {
+  const slots = Array.from({ length: 9 }, (_, index) => index);
+  let currentSlot = 0;
+  let x = Math.floor(state.studio.canvasSize / 2);
+  let y = Math.floor(state.studio.canvasSize / 2);
+  let drawn = 0;
+  const halfBrush = Math.floor((brushSize - 1) / 2);
+
+  const stamp = () => {
+    const colorIndex = slots[currentSlot] ?? 0;
+    const rgb = state.studio.colorMode === "official" ? officialPaletteRgb(colorIndex) : { r: 0, g: 0, b: 0 };
+    ctx.fillStyle = `rgb(${rgb.r}, ${rgb.g}, ${rgb.b})`;
+
+    for (let dy = 0; dy < brushSize; dy += 1) {
+      for (let dx = 0; dx < brushSize; dx += 1) {
+        const px = x - halfBrush + dx;
+        const py = y - halfBrush + dy;
+
+        if (px >= 0 && py >= 0 && px < state.studio.canvasSize && py < state.studio.canvasSize) {
+          ctx.fillRect(px, py, 1, 1);
+        }
+      }
+    }
+
+    drawn += 1;
+  };
+
+  for (const rawCommand of commands) {
+    const command = String(rawCommand).trim();
+    const parts = command.split(/\s+/);
+
+    if (!command || command.startsWith("#") || parts[0] === "CFG") {
+      continue;
+    }
+
+    if (parts[0] === "M") {
+      x += Number(parts[1]) || 0;
+      y += Number(parts[2]) || 0;
+    } else if (parts[0] === "L") {
+      const dx = Number(parts[1]) || 0;
+      const dy = Number(parts[2]) || 0;
+      const steps = Math.abs(dx) + Math.abs(dy);
+      const sx = Math.sign(dx);
+      const sy = Math.sign(dy);
+      stamp();
+      for (let step = 0; step < steps; step += 1) {
+        x += sx;
+        y += sy;
+        stamp();
+      }
+    } else if (parts[0] === "P") {
+      stamp();
+    } else if (parts[0] === "C") {
+      currentSlot = Number(parts[1]) || 0;
+    } else if (parts[0] === "BC" && parts[1] !== "RESET") {
+      slots[Number(parts[1]) || 0] = (Number(parts[2]) || 0) * 12 + (Number(parts[3]) || 0);
+    }
+  }
+
+  return drawn;
 }
 
 function renderPreviewBounds(profile, imageBounds) {
@@ -704,8 +1048,8 @@ async function refreshStudioPreview() {
   }
 }
 
-async function executeStudioCommands({ logPrefix }) {
-  if (!state.commands.length) {
+async function executeStudioCommands({ logPrefix, commands = state.commands }) {
+  if (!commands.length) {
     appendLog(els.studioLogOutput, "没有可执行的命令。");
     return false;
   }
@@ -731,7 +1075,7 @@ async function executeStudioCommands({ logPrefix }) {
       headers: { "content-type": "application/json" },
       body: JSON.stringify({
         target: "serial",
-        commands: state.commands,
+        commands,
         portPath: state.selectedPortPath,
         baudRate: state.studio.profile.baudRate,
         ackTimeoutMs: state.studio.profile.ackTimeoutMs,
@@ -754,6 +1098,95 @@ async function executeStudioCommands({ logPrefix }) {
     return false;
   } finally {
     setStudioBusy(false);
+  }
+}
+
+function parseCustomCommandText(text) {
+  return String(text ?? "")
+    .split(/\r?\n/u)
+    .map((line) => line.trim())
+    .filter((line) => line && !line.startsWith("#"));
+}
+
+function normalizeCustomCommandInputs() {
+  els.customCommandsInput.value = parseCustomCommandText(els.customCommandsInput.value).join("\n");
+  renderCustomPreview();
+}
+
+function renderCustomPreview() {
+  state.custom.commands = parseCustomCommandText(els.customCommandsInput.value);
+
+  const canvas = els.customReplayCanvas;
+  const ctx = canvas.getContext("2d");
+
+  canvas.width = state.studio.canvasSize;
+  canvas.height = state.studio.canvasSize;
+
+  if (!ctx) {
+    return;
+  }
+
+  ctx.clearRect(0, 0, canvas.width, canvas.height);
+
+  let drawn = 0;
+  drawn += runScriptOnReplayCanvas(ctx, state.custom.commands, state.custom.brushSize);
+
+  const totalCommands = state.custom.commands.length;
+  els.customStatCommands.textContent = String(totalCommands);
+  els.customStatDrawn.textContent = String(drawn);
+  els.customStatMode.textContent = `brush ${state.custom.brushSize}`;
+  syncCustomUi();
+}
+
+async function executeCustomCommands(commands, logPrefix) {
+  if (!commands.length) {
+    appendLog(els.customLogOutput, "没有可执行的命令。");
+    return false;
+  }
+
+  if (!state.selectedPortPath) {
+    appendLog(els.customLogOutput, "请先选择一个串口设备。");
+    return false;
+  }
+
+  if (!isControllerReadyForStudio()) {
+    appendLog(els.customLogOutput, "开始执行前，请先到“手柄测试”页把手柄连接状态跑到“已就绪”。");
+    switchPage("controller");
+    return false;
+  }
+
+  appendLog(els.customLogOutput, `${logPrefix}：${commands.length} 条命令`);
+  syncCustomUi();
+
+  try {
+    const response = await fetch("/api/execution/start", {
+      method: "POST",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify({
+        target: "serial",
+        commands,
+        portPath: state.selectedPortPath,
+        baudRate: state.studio.profile.baudRate,
+        ackTimeoutMs: state.studio.profile.ackTimeoutMs,
+        retries: state.studio.profile.commandRetryCount,
+      }),
+    });
+    const payload = await response.json();
+
+    if (!response.ok) {
+      applySerialSessionSnapshot(payload.session);
+      throw new Error(payload.error ?? "执行失败");
+    }
+
+    applySerialSessionSnapshot(payload.session);
+    applyCustomExecutionSnapshot(payload.execution);
+    startCustomExecutionPolling();
+    return true;
+  } catch (error) {
+    appendLog(els.customLogOutput, `执行失败：${getErrorMessage(error)}`);
+    return false;
+  } finally {
+    syncCustomUi();
   }
 }
 
@@ -782,6 +1215,33 @@ els.downloadButton.addEventListener("click", () => {
   URL.revokeObjectURL(url);
   appendLog(els.studioLogOutput, "脚本文件已下载。");
 });
+
+async function copyCommandsToClipboard(commands, label) {
+  if (!commands.length) {
+    return;
+  }
+
+  await navigator.clipboard.writeText(commands.join("\n"));
+  appendLog(els.studioLogOutput, `${label} 已复制到剪贴板。`);
+}
+
+function downloadCommands(commands, filename, label) {
+  if (!commands.length) {
+    return;
+  }
+
+  const blob = new Blob([`${commands.join("\n")}\n`], {
+    type: "text/plain;charset=utf-8",
+  });
+  const url = URL.createObjectURL(blob);
+  const link = document.createElement("a");
+  link.href = url;
+  link.download = filename;
+  link.click();
+  URL.revokeObjectURL(url);
+  appendLog(els.studioLogOutput, `${label} 已下载。`);
+}
+
 
 els.studioClearLogButton.addEventListener("click", () => {
   clearLog(els.studioLogOutput);
@@ -1231,6 +1691,16 @@ function setStudioBusy(isBusy) {
   els.offsetYRange.disabled = isBusy;
   els.sizeSelect.disabled = isBusy;
   els.brushSizeSelect.disabled = isBusy;
+  els.speedPresetSelect.disabled = isBusy;
+  els.speedPressInput.disabled = isBusy;
+  els.speedDelayInput.disabled = isBusy;
+  els.ditherModeSelect.disabled = isBusy;
+  els.ditherAmountRange.disabled = isBusy;
+  els.colorDistanceSelect.disabled = isBusy;
+  els.resizeModeSelect.disabled = isBusy;
+  els.brightnessRange.disabled = isBusy;
+  els.contrastRange.disabled = isBusy;
+  els.saturationRange.disabled = isBusy;
   els.copyButton.disabled = isBusy || state.commands.length === 0;
   els.downloadButton.disabled = isBusy || state.commands.length === 0;
   syncStudioUi();
@@ -1238,6 +1708,111 @@ function setStudioBusy(isBusy) {
 
 function isStudioExecutionActive() {
   return ["running", "paused", "stopping"].includes(state.studio.execution.status);
+}
+
+function formatStudioClock(ms) {
+  if (!Number.isFinite(ms) || ms < 0) {
+    return "--";
+  }
+
+  const totalSeconds = Math.floor(ms / 1000);
+  const hours = Math.floor(totalSeconds / 3600);
+  const minutes = Math.floor((totalSeconds % 3600) / 60);
+  const seconds = totalSeconds % 60;
+
+  if (hours > 0) {
+    return `${hours}:${String(minutes).padStart(2, "0")}:${String(seconds).padStart(2, "0")}`;
+  }
+
+  return `${minutes}:${String(seconds).padStart(2, "0")}`;
+}
+
+function pauseStudioExecutionClock() {
+  const clock = state.studio.executionClock;
+
+  if (clock.runningSince !== null) {
+    clock.elapsedMs += performance.now() - clock.runningSince;
+    clock.runningSince = null;
+  }
+}
+
+function resumeStudioExecutionClock() {
+  const clock = state.studio.executionClock;
+
+  if (clock.runningSince === null) {
+    clock.runningSince = performance.now();
+  }
+}
+
+function getStudioExecutionElapsedMs() {
+  const clock = state.studio.executionClock;
+
+  if (clock.runningSince === null) {
+    return clock.elapsedMs;
+  }
+
+  return clock.elapsedMs + performance.now() - clock.runningSince;
+}
+
+function syncStudioExecutionClock(execution, isNewExecution) {
+  const clock = state.studio.executionClock;
+
+  if (isNewExecution) {
+    state.studio.executionClock = {
+      id: execution.id,
+      elapsedMs: 0,
+      runningSince: execution.status === "running" ? performance.now() : null,
+      avgMsPerCommand: null,
+      lastDone: execution.completedCommands,
+      lastSampleElapsedMs: 0,
+    };
+    return;
+  }
+
+  if (execution.status === "running") {
+    resumeStudioExecutionClock();
+  } else {
+    pauseStudioExecutionClock();
+  }
+
+  const elapsed = getStudioExecutionElapsedMs();
+  const deltaDone = execution.completedCommands - clock.lastDone;
+  const deltaMs = elapsed - clock.lastSampleElapsedMs;
+
+  if (execution.status === "running" && deltaDone > 0 && deltaMs > 0) {
+    const sampleMsPerCommand = deltaMs / deltaDone;
+    clock.avgMsPerCommand =
+      clock.avgMsPerCommand === null
+        ? sampleMsPerCommand
+        : clock.avgMsPerCommand * 0.65 + sampleMsPerCommand * 0.35;
+    clock.lastDone = execution.completedCommands;
+    clock.lastSampleElapsedMs = elapsed;
+  } else if (execution.completedCommands < clock.lastDone) {
+    clock.lastDone = execution.completedCommands;
+    clock.lastSampleElapsedMs = elapsed;
+  }
+}
+
+function getStudioExecutionTimerLabel() {
+  const execution = state.studio.execution;
+
+  if (!execution.id || execution.totalCommands <= 0) {
+    return "";
+  }
+
+  const elapsed = getStudioExecutionElapsedMs();
+  const remainingCommands = Math.max(0, execution.totalCommands - execution.completedCommands);
+  let remaining = "--";
+
+  if (remainingCommands === 0) {
+    remaining = "0:00";
+  } else if (state.studio.executionClock.avgMsPerCommand !== null) {
+    remaining = formatStudioClock(state.studio.executionClock.avgMsPerCommand * remainingCommands);
+  } else if (execution.completedCommands > 0) {
+    remaining = formatStudioClock((elapsed / execution.completedCommands) * remainingCommands);
+  }
+
+  return ` · 已执行 ${formatStudioClock(elapsed)} · 预计剩余 ${remaining}`;
 }
 
 function applyStudioExecutionSnapshot(snapshot) {
@@ -1281,6 +1856,7 @@ function applyStudioExecutionSnapshot(snapshot) {
         : state.studio.execution.error,
     lineCount: nextLineCount,
   };
+  syncStudioExecutionClock(state.studio.execution, isNewExecution);
 
   newLines.forEach((line) => appendLog(els.studioLogOutput, `[device] ${line}`));
 
@@ -1353,6 +1929,199 @@ async function sendStudioExecutionControl(action, label) {
     applySerialSessionSnapshot(payload.session);
   } catch (error) {
     appendLog(els.studioLogOutput, `${label}失败：${getErrorMessage(error)}`);
+  }
+}
+
+function isCustomExecutionActive() {
+  return ["running", "paused", "stopping"].includes(state.custom.execution.status);
+}
+
+function pauseCustomExecutionClock() {
+  const clock = state.custom.executionClock;
+  if (clock.runningSince !== null) {
+    clock.elapsedMs += performance.now() - clock.runningSince;
+    clock.runningSince = null;
+  }
+}
+
+function resumeCustomExecutionClock() {
+  const clock = state.custom.executionClock;
+  if (clock.runningSince === null) {
+    clock.runningSince = performance.now();
+  }
+}
+
+function getCustomExecutionElapsedMs() {
+  const clock = state.custom.executionClock;
+  return clock.runningSince === null ? clock.elapsedMs : clock.elapsedMs + performance.now() - clock.runningSince;
+}
+
+function syncCustomExecutionClock(execution, isNewExecution) {
+  const clock = state.custom.executionClock;
+
+  if (isNewExecution) {
+    state.custom.executionClock = {
+      id: execution.id,
+      elapsedMs: 0,
+      runningSince: execution.status === "running" ? performance.now() : null,
+      avgMsPerCommand: null,
+      lastDone: execution.completedCommands,
+      lastSampleElapsedMs: 0,
+    };
+    return;
+  }
+
+  if (execution.status === "running") {
+    resumeCustomExecutionClock();
+  } else {
+    pauseCustomExecutionClock();
+  }
+
+  const elapsed = getCustomExecutionElapsedMs();
+  const deltaDone = execution.completedCommands - clock.lastDone;
+  const deltaMs = elapsed - clock.lastSampleElapsedMs;
+
+  if (execution.status === "running" && deltaDone > 0 && deltaMs > 0) {
+    const sampleMsPerCommand = deltaMs / deltaDone;
+    clock.avgMsPerCommand =
+      clock.avgMsPerCommand === null
+        ? sampleMsPerCommand
+        : clock.avgMsPerCommand * 0.65 + sampleMsPerCommand * 0.35;
+    clock.lastDone = execution.completedCommands;
+    clock.lastSampleElapsedMs = elapsed;
+  } else if (execution.completedCommands < clock.lastDone) {
+    clock.lastDone = execution.completedCommands;
+    clock.lastSampleElapsedMs = elapsed;
+  }
+}
+
+function getCustomExecutionTimerLabel() {
+  const execution = state.custom.execution;
+  if (!execution.id || execution.totalCommands <= 0) {
+    return "";
+  }
+
+  const elapsed = getCustomExecutionElapsedMs();
+  const remainingCommands = Math.max(0, execution.totalCommands - execution.completedCommands);
+  let remaining = "--";
+
+  if (remainingCommands === 0) {
+    remaining = "0:00";
+  } else if (state.custom.executionClock.avgMsPerCommand !== null) {
+    remaining = formatStudioClock(state.custom.executionClock.avgMsPerCommand * remainingCommands);
+  } else if (execution.completedCommands > 0) {
+    remaining = formatStudioClock((elapsed / execution.completedCommands) * remainingCommands);
+  }
+
+  return ` · 已执行 ${formatStudioClock(elapsed)} · 预计剩余 ${remaining}`;
+}
+
+function applyCustomExecutionSnapshot(snapshot) {
+  if (!snapshot || typeof snapshot !== "object") {
+    return;
+  }
+
+  const previousId = state.custom.execution.id;
+  const nextId = snapshot.id ?? null;
+  const isNewExecution = previousId !== nextId;
+  const existingLineCount = isNewExecution ? 0 : state.custom.execution.lineCount;
+  const lines = Array.isArray(snapshot.lines) ? snapshot.lines : [];
+  const nextLineCount = lines.length;
+  const newLines = lines.slice(existingLineCount);
+
+  state.custom.execution = {
+    ...state.custom.execution,
+    id: nextId,
+    status: typeof snapshot.status === "string" ? snapshot.status : state.custom.execution.status,
+    totalCommands:
+      typeof snapshot.totalCommands === "number" ? snapshot.totalCommands : state.custom.execution.totalCommands,
+    completedCommands:
+      typeof snapshot.completedCommands === "number"
+        ? snapshot.completedCommands
+        : state.custom.execution.completedCommands,
+    currentCommand:
+      typeof snapshot.currentCommand === "string" || snapshot.currentCommand === null
+        ? snapshot.currentCommand
+        : state.custom.execution.currentCommand,
+    startedAt:
+      typeof snapshot.startedAt === "number" || snapshot.startedAt === null
+        ? snapshot.startedAt
+        : state.custom.execution.startedAt,
+    finishedAt:
+      typeof snapshot.finishedAt === "number" || snapshot.finishedAt === null
+        ? snapshot.finishedAt
+        : state.custom.execution.finishedAt,
+    error:
+      typeof snapshot.error === "string" || snapshot.error === null ? snapshot.error : state.custom.execution.error,
+    lineCount: nextLineCount,
+  };
+  syncCustomExecutionClock(state.custom.execution, isNewExecution);
+  newLines.forEach((line) => appendLog(els.customLogOutput, `[device] ${line}`));
+
+  if (isCustomExecutionActive()) {
+    startCustomExecutionPolling();
+  } else {
+    stopCustomExecutionPolling();
+  }
+
+  syncCustomUi();
+}
+
+async function pollCustomExecutionStatus() {
+  try {
+    const response = await fetch("/api/execution/status");
+    const payload = await response.json();
+
+    if (!response.ok) {
+      applySerialSessionSnapshot(payload.session);
+      throw new Error(payload.error ?? "读取执行状态失败");
+    }
+
+    applyCustomExecutionSnapshot(payload.execution);
+    applySerialSessionSnapshot(payload.session);
+  } catch (error) {
+    stopCustomExecutionPolling();
+    appendLog(els.customLogOutput, `读取执行状态失败：${getErrorMessage(error)}`);
+  }
+}
+
+function startCustomExecutionPolling() {
+  if (customExecutionPollTimer) {
+    return;
+  }
+
+  customExecutionPollTimer = window.setInterval(() => {
+    void pollCustomExecutionStatus();
+  }, 800);
+}
+
+function stopCustomExecutionPolling() {
+  if (!customExecutionPollTimer) {
+    return;
+  }
+
+  window.clearInterval(customExecutionPollTimer);
+  customExecutionPollTimer = null;
+}
+
+async function sendCustomExecutionControl(action, label) {
+  try {
+    const response = await fetch(`/api/execution/${action}`, {
+      method: "POST",
+      headers: { "content-type": "application/json" },
+    });
+    const payload = await response.json();
+
+    if (!response.ok) {
+      applySerialSessionSnapshot(payload.session);
+      throw new Error(payload.error ?? `${label}失败`);
+    }
+
+    appendLog(els.customLogOutput, `${label}请求已发送。`);
+    applyCustomExecutionSnapshot(payload.execution);
+    applySerialSessionSnapshot(payload.session);
+  } catch (error) {
+    appendLog(els.customLogOutput, `${label}失败：${getErrorMessage(error)}`);
   }
 }
 
@@ -1437,6 +2206,7 @@ function applySerialSessionSnapshot(snapshot) {
         : state.serialSession.idleTimeoutMs,
     lastUsedAt: typeof snapshot.lastUsedAt === "number" ? snapshot.lastUsedAt : null,
   };
+  syncCustomUi();
   syncControllerUi();
 }
 
@@ -1604,24 +2374,25 @@ function renderStudioConnectionStatus() {
 
 function renderStudioExecutionStatus() {
   const execution = state.studio.execution;
+  const timerLabel = getStudioExecutionTimerLabel();
 
   switch (execution.status) {
     case "running":
       els.studioExecutionStatus.textContent = `绘制进行中：${execution.completedCommands} / ${execution.totalCommands}${
         execution.currentCommand ? ` · 当前命令 ${execution.currentCommand}` : ""
-      }`;
+      }${timerLabel}`;
       break;
     case "paused":
-      els.studioExecutionStatus.textContent = `绘制已暂停：${execution.completedCommands} / ${execution.totalCommands}`;
+      els.studioExecutionStatus.textContent = `绘制已暂停：${execution.completedCommands} / ${execution.totalCommands}${timerLabel}`;
       break;
     case "stopping":
-      els.studioExecutionStatus.textContent = `正在中断绘制：${execution.completedCommands} / ${execution.totalCommands}`;
+      els.studioExecutionStatus.textContent = `正在中断绘制：${execution.completedCommands} / ${execution.totalCommands}${timerLabel}`;
       break;
     case "completed":
-      els.studioExecutionStatus.textContent = `绘制已完成：${execution.completedCommands} / ${execution.totalCommands}`;
+      els.studioExecutionStatus.textContent = `绘制已完成：${execution.completedCommands} / ${execution.totalCommands}${timerLabel}`;
       break;
     case "stopped":
-      els.studioExecutionStatus.textContent = `绘制已中断：${execution.completedCommands} / ${execution.totalCommands}`;
+      els.studioExecutionStatus.textContent = `绘制已中断：${execution.completedCommands} / ${execution.totalCommands}${timerLabel}`;
       break;
     case "failed":
       els.studioExecutionStatus.textContent = `绘制失败：${execution.error ?? "请查看执行日志。"}`;
@@ -1630,6 +2401,63 @@ function renderStudioExecutionStatus() {
       els.studioExecutionStatus.textContent = "当前未开始绘制。";
       break;
   }
+}
+
+function renderCustomExecutionStatus() {
+  const execution = state.custom.execution;
+  const timerLabel = getCustomExecutionTimerLabel();
+
+  switch (execution.status) {
+    case "running":
+      els.customExecutionStatus.textContent = `自定义脚本执行中：${execution.completedCommands} / ${execution.totalCommands}${
+        execution.currentCommand ? ` · 当前命令 ${execution.currentCommand}` : ""
+      }${timerLabel}`;
+      break;
+    case "paused":
+      els.customExecutionStatus.textContent = `自定义脚本已暂停：${execution.completedCommands} / ${execution.totalCommands}${timerLabel}`;
+      break;
+    case "stopping":
+      els.customExecutionStatus.textContent = `正在中断自定义脚本：${execution.completedCommands} / ${execution.totalCommands}${timerLabel}`;
+      break;
+    case "completed":
+      els.customExecutionStatus.textContent = `自定义脚本已完成：${execution.completedCommands} / ${execution.totalCommands}${timerLabel}`;
+      break;
+    case "stopped":
+      els.customExecutionStatus.textContent = `自定义脚本已中断：${execution.completedCommands} / ${execution.totalCommands}${timerLabel}`;
+      break;
+    case "failed":
+      els.customExecutionStatus.textContent = `自定义脚本失败：${execution.error ?? "请查看执行日志。"}`;
+      break;
+    default:
+      els.customExecutionStatus.textContent = "当前未开始执行。";
+      break;
+  }
+}
+
+function syncCustomUi() {
+  const executionActive = isCustomExecutionActive();
+  const executionPaused = state.custom.execution.status === "paused";
+  const executionRunning = state.custom.execution.status === "running";
+  const hasPort = Boolean(state.selectedPortPath);
+  const controllerReady = isControllerReadyForStudio();
+  const combinedCommands = state.custom.commands;
+
+  els.customBrushSizeSelect.value = String(state.custom.brushSize);
+  els.customBrushSizeSelect.disabled = executionActive;
+  els.customCommandsInput.disabled = executionActive;
+  els.customPortSelect.disabled = executionActive;
+  els.customPreviewButton.disabled = executionActive;
+  els.customNormalizeButton.disabled = executionActive;
+  els.customClearButton.disabled = executionActive;
+  els.customRefreshPortsButton.disabled = executionActive;
+  els.customExecuteButton.disabled =
+    executionActive || combinedCommands.length === 0 || !hasPort || !controllerReady;
+  els.customPauseButton.disabled = !executionRunning;
+  els.customResumeButton.disabled = !executionPaused;
+  els.customStopButton.disabled = !(executionRunning || executionPaused);
+  els.customCopyButton.disabled = combinedCommands.length === 0;
+  els.customDownloadButton.disabled = combinedCommands.length === 0;
+  renderCustomExecutionStatus();
 }
 
 function renderOfficialPalettePreview() {
@@ -1708,11 +2536,22 @@ function renderOfficialPalettePreview() {
       coord.className = "official-palette-coord";
       coord.textContent = `P${index}`;
 
+      meta.append(coord);
+
+      if (isUsed) {
+        const count = document.createElement("span");
+        count.className = "official-palette-count";
+        const n = colorCounts[flatIndex] ?? 0;
+        count.textContent = n >= 1000 ? `${(n / 1000).toFixed(1)}k` : String(n);
+        count.title = `${n} px`;
+        meta.append(count);
+      }
+
       const hex = document.createElement("span");
       hex.className = "official-palette-hex";
       hex.textContent = colorHex;
 
-      meta.append(coord, hex);
+      meta.append(hex);
       cell.append(swatch, meta);
       els.officialPaletteGrid.appendChild(cell);
     });
@@ -1760,6 +2599,25 @@ function syncStudioUi() {
   els.previewGuideSelect.value = state.studio.previewGuideMode;
   els.previewCanvas.dataset.guide = state.studio.previewGuideMode;
   els.colorModeSelect.value = state.studio.colorMode;
+  els.speedPresetSelect.value = state.studio.speedPreset;
+  els.speedPressInput.value = String(state.studio.buttonPressMs);
+  els.speedDelayInput.value = String(state.studio.inputDelayMs);
+  els.speedCustomRow.classList.toggle("hidden", state.studio.speedPreset !== "custom");
+  els.ditherModeSelect.value = state.studio.ditherMode;
+  els.ditherAmountRange.value = String(state.studio.ditherAmount);
+  els.ditherAmountValue.textContent = `${state.studio.ditherAmount}%`;
+  els.colorDistanceSelect.value = state.studio.colorDistanceMode;
+  els.resizeModeSelect.value = state.studio.resizeMode;
+  els.brightnessRange.value = String(state.studio.brightness);
+  els.brightnessValue.textContent = String(state.studio.brightness);
+  els.contrastRange.value = String(state.studio.contrast);
+  els.contrastValue.textContent = String(state.studio.contrast);
+  els.saturationRange.value = String(state.studio.saturation);
+  els.saturationValue.textContent = String(state.studio.saturation);
+  els.mergeSimilarCheckbox.checked = state.studio.mergeSimilarColors;
+  els.mergeThresholdRange.value = String(state.studio.mergeThreshold);
+  els.pathStrategyCheckbox.checked = state.studio.pathStrategy === "nearest";
+  els.mergeThresholdValue.textContent = String(state.studio.mergeThreshold);
   els.autoRemoveBackgroundCheckbox.checked = state.studio.removeBackground;
   syncStudioColorCountOptions();
   const backgroundHint = state.studio.removeBackground
@@ -1779,7 +2637,7 @@ function syncStudioUi() {
       `当前会先按 ${state.studio.imageScalePercent}% 调整图片大小，再把图片压到 ${state.studio.colorCount} 个官方色以内，并映射到游戏内置的 7x12 官方色盘，再按 ${state.studio.brushSize} 号笔生成。${scaleHint}${positionHint}开始前请保持右侧 9 个槽位默认颜色不变。${squareBrushHint}${backgroundHint}`;
   } else {
     els.studioModeHint.textContent =
-      `当前会先按 ${state.studio.imageScalePercent}% 调整图片大小，再把图片自动量化到最多 ${state.studio.colorCount} 个颜色，并按批次写入游戏的 9 个自定义槽位后进行绘制。下方“当前预览用色”会完整列出这次预览实际用到的全部颜色。${scaleHint}${positionHint}这条路线仍属于实验能力，当前优先目标是输入稳定性，不保证所有图片都稳定。${squareBrushHint}${backgroundHint}`;
+      `当前会先按 ${state.studio.imageScalePercent}% 调整图片大小，再把图片自动量化到最多 ${state.studio.colorCount} 个颜色，并按批次写入游戏的 9 个自定义槽位后进行绘制。下方”当前预览用色”会完整列出这次预览实际用到的全部颜色。${scaleHint}${positionHint}这条路线仍属于实验能力，当前优先目标是输入稳定性，不保证所有图片都稳定。${squareBrushHint}${backgroundHint}`;
   }
   els.studioPortSelect.disabled = state.studio.busy || executionActive;
   els.refreshPortsButton.disabled = state.studio.busy || executionActive;
@@ -1792,6 +2650,20 @@ function syncStudioUi() {
   els.offsetYRange.disabled = state.studio.busy || executionActive;
   els.offsetYInput.disabled = state.studio.busy || executionActive;
   els.colorModeSelect.disabled = state.studio.busy || executionActive;
+  els.speedPresetSelect.disabled = state.studio.busy || executionActive;
+  els.speedPressInput.disabled = state.studio.busy || executionActive;
+  els.speedDelayInput.disabled = state.studio.busy || executionActive;
+  els.ditherModeSelect.disabled = state.studio.busy || executionActive;
+  els.ditherAmountRange.disabled = state.studio.busy || executionActive || state.studio.ditherMode === "none";
+  els.colorDistanceSelect.disabled = state.studio.busy || executionActive;
+  els.resizeModeSelect.disabled = state.studio.busy || executionActive;
+  els.brightnessRange.disabled = state.studio.busy || executionActive;
+  els.contrastRange.disabled = state.studio.busy || executionActive;
+  els.saturationRange.disabled = state.studio.busy || executionActive;
+  els.mergeSimilarCheckbox.disabled =
+    state.studio.busy || executionActive || state.studio.colorMode === "mono";
+  els.mergeThresholdRange.disabled =
+    state.studio.busy || executionActive || state.studio.colorMode === "mono" || !state.studio.mergeSimilarColors;
   els.autoRemoveBackgroundCheckbox.disabled = state.studio.busy || executionActive;
   els.previewGuideSelect.disabled = false;
   els.colorCountSelect.disabled =
@@ -2126,7 +2998,7 @@ function pickPreferredPortPath() {
 }
 
 function renderPortSelects() {
-  const selects = [els.studioPortSelect, els.firmwarePortSelect, els.controllerPortSelect];
+  const selects = [els.studioPortSelect, els.customPortSelect, els.firmwarePortSelect, els.controllerPortSelect];
 
   selects.forEach((select) => {
     select.innerHTML = "";
@@ -2451,6 +3323,65 @@ function setStudioImageOffsetYPercent(value) {
   }
 }
 
+function applyStudioSpeedPresetValue(value) {
+  const [press, delay] = String(value).split(",").map((part) => Number(part));
+
+  if (Number.isFinite(press) && Number.isFinite(delay)) {
+    state.studio.buttonPressMs = normalizeStudioNumericValue(press, state.studio.buttonPressMs, STUDIO_SPEED_LIMITS);
+    state.studio.inputDelayMs = normalizeStudioNumericValue(delay, state.studio.inputDelayMs, STUDIO_SPEED_LIMITS);
+  }
+}
+
+function setStudioSpeedPreset(value) {
+  const nextPreset = value === "custom" ? "custom" : String(value);
+  state.studio.speedPreset = nextPreset;
+
+  if (nextPreset !== "custom") {
+    applyStudioSpeedPresetValue(nextPreset);
+  }
+
+  syncStudioUi();
+  scheduleStudioPreviewRefresh();
+}
+
+function setStudioButtonPressMs(value) {
+  const nextValue = normalizeStudioNumericValue(value, state.studio.buttonPressMs, STUDIO_SPEED_LIMITS);
+  const changed = nextValue !== state.studio.buttonPressMs || state.studio.speedPreset !== "custom";
+  state.studio.buttonPressMs = nextValue;
+  state.studio.speedPreset = "custom";
+  syncStudioUi();
+
+  if (changed) {
+    scheduleStudioPreviewRefresh();
+  }
+}
+
+function setStudioInputDelayMs(value) {
+  const nextValue = normalizeStudioNumericValue(value, state.studio.inputDelayMs, STUDIO_SPEED_LIMITS);
+  const changed = nextValue !== state.studio.inputDelayMs || state.studio.speedPreset !== "custom";
+  state.studio.inputDelayMs = nextValue;
+  state.studio.speedPreset = "custom";
+  syncStudioUi();
+
+  if (changed) {
+    scheduleStudioPreviewRefresh();
+  }
+}
+
+function setStudioAdjustment(key, value) {
+  const nextValue = normalizeStudioNumericValue(value, state.studio[key], {
+    min: -100,
+    max: 100,
+  });
+  const changed = nextValue !== state.studio[key];
+  state.studio[key] = nextValue;
+  syncStudioUi();
+
+  if (changed) {
+    scheduleStudioPreviewRefresh();
+  }
+}
+
 function formatOffsetLabel(value) {
   if (value === 0) {
     return "居中";
@@ -2520,6 +3451,7 @@ async function init() {
   ]);
   renderPortSelects();
   syncStudioUi();
+  syncCustomUi();
   syncFirmwareUi();
   syncControllerUi();
   renderControllerStatus();

--- a/apps/desktop/src/web/static/index.html
+++ b/apps/desktop/src/web/static/index.html
@@ -28,7 +28,7 @@
           </p>
           <p class="subcopy">
             推荐顺序是先刷固件，再做手柄测试，最后回到“脚本生成”页导入图片并先点“仅生成命令”。手柄测试未通过时，不允许开始正式绘制。开始前请确认
-            Switch 处于初始绘画页面、画笔停在画布中心、侧边色彩槽保持默认；“自定义多色（自动量化）”已开放实验入口，但稳定性仍弱于“官方色绘制”。建议首次先用简单图和大画笔测试，开始绘制后不要再操作手柄或触碰屏幕，以免错位。
+            Switch 处于初始绘画页面、画笔停在画布中心、侧边色彩槽保持默认；”自定义多色（自动量化）”已开放实验入口，但稳定性仍弱于”官方色绘制”。建议首次先用简单图和大画笔测试，开始绘制后不要再操作手柄或触碰屏幕，以免错位。
           </p>
         </div>
         <div class="hero-side">
@@ -65,6 +65,10 @@
           <button class="page-tab" data-page-target="firmware" type="button">
             <span class="page-tab-title">刷入固件</span>
             <small class="page-tab-meta">编译、烧录、排错</small>
+          </button>
+          <button class="page-tab" data-page-target="custom" type="button">
+            <span class="page-tab-title">自定义命令</span>
+            <small class="page-tab-meta">粘贴、预览、执行</small>
           </button>
           <button class="page-tab" data-page-target="controller" type="button">
             <span class="page-tab-title">手柄测试</span>
@@ -178,7 +182,104 @@
                   <option value="128">128 色</option>
                 </select>
               </label>
+
+
+              <label>
+                <span>绘制速度</span>
+                <select id="speed-preset-select">
+                  <option value="100,100">默认 100/100（最稳）</option>
+                  <option value="60,60" selected>较快 60/60</option>
+                  <option value="40,40">激进 40/40</option>
+                  <option value="25,25">极限 25/25</option>
+                  <option value="custom">自定义</option>
+                </select>
+              </label>
+
+              <label>
+                <span>抖动算法</span>
+                <select id="dither-mode-select">
+                  <option value="none">无</option>
+                  <option value="fs" selected>Floyd-Steinberg</option>
+                  <option value="atkinson">Atkinson</option>
+                  <option value="ordered">Bayer</option>
+                </select>
+              </label>
+
+              <label>
+                <span>颜色距离</span>
+                <select id="color-distance-select">
+                  <option value="weighted" selected>加权 RGB</option>
+                  <option value="rgb">欧氏 RGB</option>
+                  <option value="lab">Lab</option>
+                </select>
+              </label>
+
+              <label>
+                <span>裁剪方式</span>
+                <select id="resize-mode-select">
+                  <option value="cover">cover</option>
+                  <option value="contain" selected>contain</option>
+                  <option value="stretch">stretch</option>
+                </select>
+              </label>
+
+              <label class="checkbox-card" for="merge-similar-checkbox">
+                <input id="merge-similar-checkbox" type="checkbox" />
+                <span class="checkbox-copy">
+                  <strong>合并同类色</strong>
+                  <small>将官方色盘中颜色相近的色块合并，减少换色次数以缩短绘制时间。</small>
+                </span>
+              </label>
+
+              <label class="checkbox-card" for="path-strategy-checkbox">
+                <input id="path-strategy-checkbox" type="checkbox" />
+                <span class="checkbox-copy">
+                  <strong>最近邻路径（实验）</strong>
+                  <small>画完一点后优先去附近同色像素，替代默认的蛇形扫描排序。</small>
+                </span>
+              </label>
             </div>
+
+            <label class="range-row">
+              <span>合并阈值</span>
+              <input id="merge-threshold-range" type="range" min="0" max="100" step="1" value="40" />
+              <strong id="merge-threshold-value">40</strong>
+            </label>
+
+            <div id="speed-custom-row" class="field-grid studio-settings-grid hidden">
+              <label>
+                <span>按键时长 ms</span>
+                <input id="speed-press-input" type="number" min="16" max="500" step="1" value="60" />
+              </label>
+              <label>
+                <span>按键间隔 ms</span>
+                <input id="speed-delay-input" type="number" min="16" max="500" step="1" value="60" />
+              </label>
+            </div>
+
+            <label class="range-row">
+              <span>抖动强度</span>
+              <input id="dither-amount-range" type="range" min="0" max="100" step="1" value="100" />
+              <strong id="dither-amount-value">100%</strong>
+            </label>
+
+            <label class="range-row">
+              <span>亮度</span>
+              <input id="brightness-range" type="range" min="-100" max="100" step="1" value="0" />
+              <strong id="brightness-value">0</strong>
+            </label>
+
+            <label class="range-row">
+              <span>对比度</span>
+              <input id="contrast-range" type="range" min="-100" max="100" step="1" value="0" />
+              <strong id="contrast-value">0</strong>
+            </label>
+
+            <label class="range-row">
+              <span>饱和度</span>
+              <input id="saturation-range" type="range" min="-100" max="100" step="1" value="0" />
+              <strong id="saturation-value">0</strong>
+            </label>
 
             <label class="range-row">
               <span id="threshold-label">单色阈值</span>
@@ -311,6 +412,14 @@
               </div>
             </div>
 
+            <div id="script-replay-row" class="preview-meta-strip hidden">
+              <div class="preview-meta-card">
+                <span>脚本回放</span>
+                <canvas id="script-replay-canvas" width="256" height="256" style="width:100%;image-rendering:pixelated;border-radius:8px;"></canvas>
+                <small id="script-replay-meta">-</small>
+              </div>
+            </div>
+
             <div class="preview-meta-strip">
               <div class="preview-meta-card">
                 <span>画布范围</span>
@@ -372,6 +481,7 @@
               <button id="copy-button" class="ghost" disabled>复制脚本</button>
               <button id="download-button" class="ghost" disabled>下载脚本</button>
             </div>
+
           </section>
 
           <section class="panel panel-log">
@@ -385,6 +495,111 @@
             </div>
 
             <pre id="log-output" class="log-output" data-empty-log="等待生成命令...">等待生成命令...</pre>
+          </section>
+        </main>
+      </section>
+
+      <section class="page" data-page="custom">
+        <section class="page-intro">
+          <div class="page-intro-copy">
+            <p class="page-kicker">自定义命令</p>
+            <h2>粘贴外部脚本，先回放确认，再直接执行</h2>
+            <p>适合导入外部生成的 Friend Maker 命令。</p>
+          </div>
+          <div class="page-step-row" aria-label="自定义命令步骤">
+            <span class="page-step">1. 粘贴命令</span>
+            <span class="page-step">2. 预览回放</span>
+            <span class="page-step">3. 发送到设备</span>
+          </div>
+        </section>
+
+        <main class="grid">
+          <section class="panel panel-form">
+            <div class="panel-head">
+              <h2>命令输入</h2>
+              <p>每行一条命令。空行和以 # 开头的注释会被忽略。</p>
+            </div>
+
+            <div class="field-grid studio-settings-grid">
+              <label>
+                <span>单段回放画笔</span>
+                <select id="custom-brush-size-select">
+                  <option value="1">1</option>
+                  <option value="3" selected>3</option>
+                  <option value="7">7</option>
+                  <option value="13">13</option>
+                  <option value="19">19</option>
+                  <option value="27">27</option>
+                </select>
+              </label>
+              <label>
+                <span>串口设备</span>
+                <select id="custom-port-select">
+                  <option value="">未检测到串口</option>
+                </select>
+              </label>
+            </div>
+
+            <textarea id="custom-commands-input" class="code-block" rows="14" spellcheck="false" placeholder="CFG INPUT 60 60 1800&#10;BC RESET&#10;BC 0 0 0&#10;C 0&#10;M -10 -10&#10;P&#10;E"></textarea>
+
+            <div class="action-row slim">
+              <button id="custom-preview-button" class="ghost" type="button">预览回放</button>
+              <button id="custom-normalize-button" class="ghost" type="button">整理命令</button>
+              <button id="custom-clear-button" class="ghost" type="button">清空</button>
+            </div>
+
+            <div class="action-row">
+              <button id="custom-execute-button" class="primary" type="button" disabled>执行脚本</button>
+            </div>
+
+            <div class="action-row slim">
+              <button id="custom-pause-button" class="ghost" type="button" disabled>暂停</button>
+              <button id="custom-resume-button" class="ghost" type="button" disabled>继续</button>
+              <button id="custom-stop-button" class="ghost" type="button" disabled>中断</button>
+            </div>
+
+            <p class="hint" id="custom-execution-status">当前未开始执行。</p>
+          </section>
+
+          <section class="panel panel-preview">
+            <div class="panel-head">
+              <h2>自定义预览</h2>
+              <p>按命令模拟移动、换色和绘制，不会连接设备。</p>
+            </div>
+            <div class="preview-frame">
+              <canvas id="custom-replay-canvas" width="256" height="256" style="width:100%;image-rendering:pixelated;border-radius:8px;"></canvas>
+            </div>
+            <div class="stat-strip">
+              <div class="stat-card">
+                <span>命令</span>
+                <strong id="custom-stat-commands">0</strong>
+              </div>
+              <div class="stat-card">
+                <span>绘制</span>
+                <strong id="custom-stat-drawn">0</strong>
+              </div>
+              <div class="stat-card">
+                <span>模式</span>
+                <strong id="custom-stat-mode">单段</strong>
+              </div>
+            </div>
+
+            <div class="action-row slim">
+              <button id="custom-copy-button" class="ghost" type="button" disabled>复制脚本</button>
+              <button id="custom-download-button" class="ghost" type="button" disabled>下载脚本</button>
+            </div>
+          </section>
+
+          <section class="panel panel-log">
+            <div class="panel-head">
+              <h2>执行日志</h2>
+              <p>这里显示自定义脚本的发送状态和设备返回信息。</p>
+            </div>
+            <div class="action-row slim log-toolbar">
+              <button id="custom-refresh-ports-button" class="ghost" type="button">刷新串口</button>
+              <button id="custom-clear-log-button" class="ghost" type="button">清空日志</button>
+            </div>
+            <pre id="custom-log-output" class="log-output" data-empty-log="等待自定义命令...">等待自定义命令...</pre>
           </section>
         </main>
       </section>

--- a/apps/desktop/src/web/static/styles.css
+++ b/apps/desktop/src/web/static/styles.css
@@ -1268,6 +1268,12 @@ input[type="range"]:focus-visible,
   color: var(--ink);
 }
 
+.official-palette-count {
+  font-size: 11px;
+  font-weight: 700;
+  color: var(--accent);
+}
+
 .hidden {
   display: none !important;
 }


### PR DESCRIPTION
## 概要

把分支上多个进阶能力一并提交。文件高度交织（前端、server、pixelize、quantize 互相调用），分多个 PR 反而难审，因此按功能在下文分章节列出，maintainer 可以按文件或章节审。所有新选项默认关闭/安全值，bc 协议输出不变，完全向后兼容。

> **依赖**：base 是 [#21](https://github.com/zhouxiyu1997/friendmaker/pull/21)（路径优化）。等 #21 合入后会自动 rebase 到 main。

## 1. 颜色量化进阶（`quantize.ts`）

- **抖动**：Floyd-Steinberg、Atkinson、Bayer 4×4
- **色彩距离度量**：加权 RGB（默认）、欧几里得 RGB、CIE Lab
- **图像调整**：亮度、对比度、饱和度滑块，在量化之前作用于源图

默认参数等价于上游原行为（无抖动、加权 RGB、调整为 0）。

## 2. 合并同类色（`pixelize.ts`）

- 新增 `mergeSimilarColorsInMap()`：按颜色频次降序贪心合并 ΔE 低于阈值的色块
- 减少绘制时的颜色切换次数
- UI 提供"合并同类色"复选框 + 阈值滑块，默认关闭
- `server.ts` 加 `normalizeMergeThreshold()` 把非数字输入兜底到默认值，避免 `NaN` 让比较恒为 false 导致合并被静默跳过

## 3. 颜色计数（`pixelize.ts` / `generateDrawPlan.ts` / `types.ts`）

- `PixelizationResult` 增加 `colorCounts: Record<colorIndex, number>`
- 沿 `generateDrawPlan` → `server.ts` → 前端透传
- 前端在官方色盘格子上叠加每色像素数（自动 `1234` / `1.2k` 格式化），便于用户判断是否要剔除碎色

## 4. 绘制速度控制（`scanline.ts` + UI）

- `generateScanlineCommands` 把 `inputConfigCommand` 的时序参数从 `DEFAULT_SAFE_INPUT_TIMING` 切换为 profile 字段（fallback 到默认）
- 暴露 `cellMoveDuration`、`inputDelay`、`buttonPressDuration`、`colorChangeDuration` 供前端调节
- 不同手柄/线路条件下可细调

## 5. 自定义命令预览页

- 新增"自定义命令"标签页：粘贴外部脚本，先回放预览再执行
- 支持复制 / 下载 / 暂停 / 继续 / 停止
- 不影响原有三页

## 6. 最近邻路径 UI 开关

- 在 studio 设置面板加 `pathStrategy` 复选框，把 #21 引入的 `nearest` 策略暴露给用户
- 通过生成 API 透传，profile 响应里回显，刷新后状态保持

## 兼容性

- 所有新参数都是可选项，默认值与上游原行为一致
- 协议输出格式（bc 命令字符串）完全未变
- `PixelizationResult` 和 `DrawPlan` 加了 `colorCounts` 字段；老调用方忽略即可

## 测试

- `npm run check` ✅
- `npm run test:desktop` ✅