### PR TITLE
fix: stabilize controller reconnect and 2MB ESP32 pairing

### DIFF
--- a/apps/desktop/src/serial/sender.ts
+++ b/apps/desktop/src/serial/sender.ts
@@ -18,6 +18,7 @@ import type { ProgressUpdate, SenderControls } from "../types.js";
 const ACK_LINE_PREFIXES = ["OK ", "ERR "] as const;
 const DEVICE_LINE_PREFIXES = ["INFO ", "WARN ", "BOOT ", "rst:"] as const;
 export const DEFAULT_SERIAL_SESSION_IDLE_TIMEOUT_MS = 15 * 60 * 1_000;
+const CONTROLLER_SEND_REPORT_FAILURE_THRESHOLD = 10;
 const COLOR_PALETTE_SLOT_COUNT = 9;
 const COLOR_PALETTE_RESET_TO_BOTTOM_STEPS = 18;
 const COLOR_PALETTE_MENU_PRESS_DURATION_MS = 90;
@@ -195,6 +196,17 @@ function getEmbeddedDeviceLine(line: string): string | null {
   return DEVICE_LINE_PREFIXES.some((prefix) => candidate.startsWith(prefix)) ? candidate : null;
 }
 
+export function isCongestedControllerSendReportLine(line: string): boolean {
+  const match =
+    /^WARN bt hid event=send-report status=(\d+) reason=(\d+) report=(\d+)$/u.exec(line.trim());
+
+  if (!match?.[1] || !match[2] || !match[3]) {
+    return false;
+  }
+
+  return match[1] !== "0" && match[2] === "8" && match[3] === "48";
+}
+
 function waitForAck(
   parser: ReadlineParser,
   port: SerialPort,
@@ -215,6 +227,7 @@ function waitForAck(
     }
 
     let settled = false;
+    let congestedControllerSendReportCount = 0;
 
     const finish = (callback: () => void) => {
       if (settled) {
@@ -273,6 +286,15 @@ function waitForAck(
           ),
         );
         return;
+      }
+
+      if (isCongestedControllerSendReportLine(line)) {
+        congestedControllerSendReportCount += 1;
+
+        if (congestedControllerSendReportCount >= CONTROLLER_SEND_REPORT_FAILURE_THRESHOLD) {
+          finish(() => reject(new Error("controller input report failed")));
+          return;
+        }
       }
 
       options?.onDeviceLine?.(line);

--- a/apps/desktop/src/web/recoverySessions.ts
+++ b/apps/desktop/src/web/recoverySessions.ts
@@ -1,4 +1,5 @@
 import path from "node:path";
+import { randomBytes } from "node:crypto";
 import { mkdir, readdir, readFile, rm, writeFile } from "node:fs/promises";
 
 import { deriveResumeProgress } from "../app/recovery.js";
@@ -95,9 +96,12 @@ function createJobId(sourceLabel: string, now = new Date()): string {
     String(now.getHours()).padStart(2, "0"),
     String(now.getMinutes()).padStart(2, "0"),
     String(now.getSeconds()).padStart(2, "0"),
+    "-",
+    String(now.getMilliseconds()).padStart(3, "0"),
   ].join("");
+  const uniqueSuffix = randomBytes(3).toString("hex");
 
-  return `${timestamp}-${sanitizeLabelSegment(path.basename(sourceLabel))}`;
+  return `${timestamp}-${uniqueSuffix}-${sanitizeLabelSegment(path.basename(sourceLabel))}`;
 }
 
 function toSummary(record: RecoverySessionRecord): RecoverySessionSummary {

--- a/apps/desktop/src/web/server.ts
+++ b/apps/desktop/src/web/server.ts
@@ -187,6 +187,7 @@ interface ManagedExecution {
   sender: SenderControls | null;
   progressMap: number[] | null;
   recoverySession: RecoverySessionRecord | null;
+  completionPromise: Promise<void> | null;
 }
 
 let executionCounter = 0;
@@ -208,6 +209,7 @@ function createEmptyExecution(): ManagedExecution {
     sender: null,
     progressMap: null,
     recoverySession: null,
+    completionPromise: null,
   };
 }
 
@@ -217,7 +219,32 @@ function resetManagedExecutionState(): void {
   managedExecution = createEmptyExecution();
 }
 
-class ManagedSerialSessionSender implements SenderControls {
+const SELECTED_UPLOAD_PORT_RETRY_GUIDANCE =
+  "Reconnect the board, make sure no other app is using the port, or choose a different port and retry.";
+
+export function formatMissingSelectedUploadPortMessage(selectedPortPath: string): string {
+  return `Selected port ${selectedPortPath} is no longer detected. Reconnect the board or choose a different port and retry.`;
+}
+
+export function formatSelectedUploadPortFailureMessage(
+  selectedPortPath: string,
+  message: string,
+): string {
+  return `Upload failed on the selected port ${selectedPortPath}. ${message} ${SELECTED_UPLOAD_PORT_RETRY_GUIDANCE}`;
+}
+
+function validateSelectedUploadPort(
+  selectedPortPath: string,
+  detectedPortPaths: string[],
+): string | null {
+  if (detectedPortPaths.length === 0 || detectedPortPaths.includes(selectedPortPath)) {
+    return null;
+  }
+
+  return formatMissingSelectedUploadPortMessage(selectedPortPath);
+}
+
+export class ManagedSerialSessionSender implements SenderControls {
   private paused = false;
   private stopped = false;
   private interruptAckWait: (() => void) | null = null;
@@ -233,15 +260,19 @@ class ManagedSerialSessionSender implements SenderControls {
   }
 
   stop(): void {
-    this.stopped = true;
+    this.requestStop();
   }
 
   forceStop(): void {
+    this.requestStop();
+  }
+
+  private requestStop(): void {
     this.stopped = true;
     this.interruptAckWait?.();
     this.interruptAckWait = null;
     void this.sessionManager.disconnect({ force: true }).catch(() => {
-      // Forced stop uses disconnect only to interrupt a blocking ACK wait.
+      // Stop uses disconnect only to interrupt a blocking ACK wait immediately.
     });
   }
 
@@ -586,22 +617,17 @@ class FirmwareFlashManager {
       }
 
       const detectedPortPaths = await this.listDetectedPorts();
-      const selectedPortDetected =
-        detectedPortPaths.length === 0 || detectedPortPaths.includes(selectedPortPath);
+      const selectedPortValidationError = validateSelectedUploadPort(
+        selectedPortPath,
+        detectedPortPaths,
+      );
 
       if (this.cancelRequested) {
         throw markLogged(new Error(this.stopReason ?? "Firmware flash cancelled by user."));
       }
 
-      if (!selectedPortDetected) {
-        this.state.uploadPortPath = null;
-        this.state.fallbackToAutoDetect = true;
-        this.appendLine(
-          `WARN selected port ${selectedPortPath} is no longer detected. Falling back to PlatformIO auto-detect.`,
-        );
-        await this.runPlatformIoUpload(environment.id, null);
-        this.finish("completed", null);
-        return;
+      if (selectedPortValidationError) {
+        throw new Error(selectedPortValidationError);
       }
 
       this.state.uploadPortPath = selectedPortPath;
@@ -619,18 +645,7 @@ class FirmwareFlashManager {
         if (!isUploadPortFailure(message)) {
           throw error;
         }
-
-        if (this.cancelRequested) {
-          throw markLogged(new Error(this.stopReason ?? "Firmware flash cancelled by user."));
-        }
-
-        this.state.uploadPortPath = null;
-        this.state.fallbackToAutoDetect = true;
-        this.appendLine(
-          `WARN upload on ${selectedPortPath} failed with a port-related error. Retrying with PlatformIO auto-detect.`,
-        );
-        await this.runPlatformIoUpload(environment.id, null);
-        this.finish("completed", null);
+        throw new Error(formatSelectedUploadPortFailureMessage(selectedPortPath, message));
       }
     } catch (error) {
       const message = error instanceof Error ? error.message : String(error);
@@ -1331,11 +1346,12 @@ async function startManagedExecution(body: {
     sender,
     progressMap: body.progressMap ?? null,
     recoverySession: body.recoverySession ?? null,
+    completionPromise: null,
   };
 
   managedExecution = execution;
 
-  void runManagedExecution(
+  const completionPromise = runManagedExecution(
     execution,
     withDefined({
       commands: body.commands,
@@ -1357,6 +1373,7 @@ async function startManagedExecution(body: {
       errorAtCommand?: number;
     },
   );
+  execution.completionPromise = completionPromise;
 
   return snapshotManagedExecution(execution);
 }
@@ -1720,20 +1737,19 @@ async function handleExecutionStop(response: ServerResponse): Promise<void> {
 
 async function handleExecutionReset(response: ServerResponse): Promise<void> {
   try {
-    if (managedExecution.sender) {
-      if (managedExecution.sender instanceof ManagedSerialSessionSender) {
-        managedExecution.sender.forceStop();
-      } else {
-        managedExecution.sender.stop();
-      }
-    }
+    const executionToReset = managedExecution;
 
-    if (managedExecution.recoverySession) {
-      applyRecoveryProgress(managedExecution.recoverySession, managedExecution.completedCommands);
-      await updateRecoverySessionStatus(
-        managedExecution,
-        resolveRecoveryTerminalStatus(managedExecution),
-      );
+    if (executionToReset.sender) {
+      executionToReset.status = "stopping";
+      appendManagedExecutionLine(executionToReset, "INFO execution reset requested");
+
+      if (executionToReset.sender instanceof ManagedSerialSessionSender) {
+        executionToReset.sender.forceStop();
+      } else {
+        executionToReset.sender.stop();
+      }
+
+      await executionToReset.completionPromise;
     }
 
     resetManagedExecutionState();

--- a/apps/desktop/src/web/server.ts
+++ b/apps/desktop/src/web/server.ts
@@ -145,7 +145,7 @@ const FIRMWARE_ENVIRONMENTS = [
   {
     id: "esp32dev_wireless",
     label: "ESP32-WROOM-32 / ESP-32S",
-    description: "推荐主线，最终用于 Bluetooth Classic 模拟 Switch Pro 手柄。",
+    description: "推荐主线，显式兼容常见 2MB flash 通用板，最终用于 Bluetooth Classic 模拟 Switch Pro 手柄。",
     recommended: true,
   },
   {

--- a/apps/desktop/src/web/static/app.js
+++ b/apps/desktop/src/web/static/app.js
@@ -136,6 +136,7 @@ const state = {
   controller: {
     busy: false,
     target: "serial",
+    autoReconnectAttempted: false,
     status: {
       tone: "idle",
       pill: "待连接",
@@ -156,6 +157,15 @@ const state = {
       connectedValue: null,
       pairedValue: null,
       readyValue: null,
+      rawReadyValue: null,
+      readyInferredValue: false,
+      unstableValue: false,
+      reconnectRecommendedValue: false,
+      sendReportFailureCount: 0,
+      lastSendReportStatus: null,
+      lastSendReportReason: null,
+      lastAclDisconnectReason: null,
+      lastDropReason: "-",
       updatedAt: null,
     },
   },
@@ -1593,6 +1603,7 @@ function stopWindowsSerialDriverPolling() {
 }
 
 els.controllerInfoButton.addEventListener("click", async () => {
+  state.controller.autoReconnectAttempted = false;
   setControllerPendingStatus({
     title: "正在检查当前手柄状态",
     detail: "正在读取开发板当前蓝牙状态；如果已经连上 Switch，会直接复用当前连接。",
@@ -1628,6 +1639,7 @@ els.controllerInfoButton.addEventListener("click", async () => {
 });
 
 els.controllerResetButton.addEventListener("click", async () => {
+  state.controller.autoReconnectAttempted = false;
   setControllerPendingStatus({
     title: "正在重置手柄蓝牙",
     detail: "正在重启蓝牙协议栈并读取最新状态，请稍等片刻。",
@@ -1643,6 +1655,7 @@ els.controllerResetButton.addEventListener("click", async () => {
 els.controllerDisconnectButton.addEventListener("click", async () => {
   setControllerBusy(true);
   stopControllerStatusPolling();
+  state.controller.autoReconnectAttempted = false;
 
   try {
     const response = await fetch("/api/serial-session/disconnect", {
@@ -2203,6 +2216,15 @@ function setControllerPendingStatus({ title, detail }) {
     connectedValue: null,
     pairedValue: null,
     readyValue: false,
+    rawReadyValue: null,
+    readyInferredValue: false,
+    unstableValue: false,
+    reconnectRecommendedValue: false,
+    sendReportFailureCount: 0,
+    lastSendReportStatus: null,
+    lastSendReportReason: null,
+    lastAclDisconnectReason: null,
+    lastDropReason: "-",
     initStep: "-",
     initError: "-",
   });
@@ -2294,6 +2316,36 @@ async function pollControllerStatus() {
   if (!ok) {
     stopControllerStatusPolling();
     appendLog(els.controllerLogOutput, "读取手柄状态失败，请重新点击“连接手柄”后再试。");
+    return;
+  }
+
+  if (state.controller.status.reconnectRecommendedValue === true) {
+    stopControllerStatusPolling();
+
+    if (!state.controller.autoReconnectAttempted) {
+      state.controller.autoReconnectAttempted = true;
+      appendLog(
+        els.controllerLogOutput,
+        "检测到手柄已经连上但报告通道持续拥塞，自动重置蓝牙并重试一次。",
+      );
+      setControllerPendingStatus({
+        title: "正在自动恢复手柄连接",
+        detail: "检测到当前连接容易立刻断联，正在重置蓝牙并重新进入可发现状态。",
+      });
+
+      const payload = await runControllerCommands(["BT RESET", "I"], "自动恢复手柄连接");
+
+      if (payload) {
+        startControllerStatusPolling();
+      }
+
+      return;
+    }
+
+    appendLog(
+      els.controllerLogOutput,
+      "自动重试后连接仍然不稳定。请重新点击“连接手柄”；如果还是容易断联，再按一下开发板上的 EN 键后重试。",
+    );
     return;
   }
 

--- a/apps/desktop/src/web/static/app.js
+++ b/apps/desktop/src/web/static/app.js
@@ -1204,8 +1204,12 @@ function formatFirmwarePortLabel(flash) {
     return flash.uploadPortPath;
   }
 
-  if (flash?.selectedPortPath) {
+  if (flash?.fallbackToAutoDetect && flash?.selectedPortPath) {
     return `自动检测（初始选择 ${flash.selectedPortPath}）`;
+  }
+
+  if (flash?.selectedPortPath) {
+    return flash.selectedPortPath;
   }
 
   return "-";
@@ -1223,7 +1227,7 @@ function updateFirmwareResultFromFlashSnapshot(flash) {
       ? "固定端口刷入失败，正在改用 PlatformIO 自动探测可用端口重试。"
       : flash.uploadPortPath
         ? "PlatformIO 正在按当前选中的串口编译并上传固件，请稍等片刻。"
-        : "PlatformIO 正在自动探测可用串口并上传固件，请稍等片刻。";
+        : "PlatformIO 正在准备按当前选中的串口上传固件，请稍等片刻。";
     setFirmwareResult({
       status: "running",
       title: "正在刷入固件",

--- a/apps/desktop/src/web/static/controllerStatus.d.ts
+++ b/apps/desktop/src/web/static/controllerStatus.d.ts
@@ -15,6 +15,15 @@ export interface DerivedControllerStatus {
   connectedValue: boolean | null;
   pairedValue: boolean | null;
   readyValue: boolean | null;
+  rawReadyValue: boolean | null;
+  readyInferredValue: boolean;
+  unstableValue: boolean;
+  reconnectRecommendedValue: boolean;
+  sendReportFailureCount: number;
+  lastSendReportStatus: number | null;
+  lastSendReportReason: number | null;
+  lastAclDisconnectReason: number | null;
+  lastDropReason: string;
   peer: string;
   initStep: string;
   initError: string;
@@ -34,6 +43,8 @@ export function shouldReuseExistingControllerConnection(status: {
   connectedValue?: boolean | null;
   authValue?: boolean | null;
   discoverableValue?: boolean | null;
+  reconnectRecommendedValue?: boolean | null;
+  unstableValue?: boolean | null;
 } | null | undefined): boolean;
 export function deriveControllerStatus(
   lines: Array<string | null | undefined>,

--- a/apps/desktop/src/web/static/controllerStatus.js
+++ b/apps/desktop/src/web/static/controllerStatus.js
@@ -35,6 +35,18 @@ function hasControllerInitError(value) {
   return value !== "-" && value !== "none" && value !== "ESP_OK";
 }
 
+function numberFromInfo(value) {
+  const normalized = String(value ?? "").trim();
+  const match = /^-?\d+/u.exec(normalized);
+
+  if (!match?.[0]) {
+    return null;
+  }
+
+  const parsed = Number.parseInt(match[0], 10);
+  return Number.isFinite(parsed) ? parsed : null;
+}
+
 export function normalizeControllerDeviceLines(lines) {
   return (lines ?? []).flatMap((line) => splitEmbeddedDeviceLine(line));
 }
@@ -84,6 +96,10 @@ export function isControllerSendableStatus({ connected, paired, ready }) {
 }
 
 export function shouldReuseExistingControllerConnection(status) {
+  if (status?.reconnectRecommendedValue === true || status?.unstableValue === true) {
+    return false;
+  }
+
   return (
     status?.readyValue === true ||
     status?.connectedValue === true ||
@@ -104,8 +120,22 @@ export function deriveControllerStatus(lines) {
   const connected = boolFromInfo(info.bt_connected);
   const paired = boolFromInfo(info.bt_paired);
   const rawReady = boolFromInfo(info.bt_ready_for_reports);
-  const ready = isControllerSendableStatus({ connected, paired, ready: rawReady });
-  const readyInferredFromPairing = rawReady !== true && connected === true && paired === true;
+  const sendReportFailureCount = numberFromInfo(info.bt_send_report_failures) ?? 0;
+  const lastSendReportStatus = numberFromInfo(info.bt_last_send_report_status);
+  const lastSendReportReason = numberFromInfo(info.bt_last_send_report_reason);
+  const lastAclDisconnectReason = numberFromInfo(info.bt_last_acl_disconnect_reason);
+  const congestedSendReport =
+    lastSendReportStatus !== null &&
+    lastSendReportStatus > 0 &&
+    lastSendReportReason === 8;
+  const unstableInferredReady =
+    rawReady !== true &&
+    connected === true &&
+    paired === true &&
+    congestedSendReport &&
+    sendReportFailureCount >= 10;
+  const readyInferredFromPairing = rawReady !== true && connected === true && paired === true && !unstableInferredReady;
+  const ready = rawReady === true || readyInferredFromPairing;
   const initError = info.bt_init_error ?? "-";
 
   let tone = "idle";
@@ -120,6 +150,12 @@ export function deriveControllerStatus(lines) {
     detail = readyInferredFromPairing
       ? "开发板已经完成 HID 连接和配对；固件报告通道字段可能滞后，但当前状态已经可以发送按钮和摇杆报告。"
       : "开发板已经完成连接并可发送按钮和摇杆报告，可以继续做手柄测试。";
+  } else if (unstableInferredReady) {
+    tone = "warning";
+    pill = "不稳定";
+    title = "连接容易断开";
+    detail =
+      `开发板已经连上 Switch，但 HID 报告通道仍在拥塞（最近一次 send-report status=${lastSendReportStatus ?? "-"} reason=${lastSendReportReason ?? "-"}，累计失败 ${sendReportFailureCount} 次），现在继续测试或开画都容易断联。建议先重置蓝牙后重新连接。`;
   } else if (connected === true) {
     tone = "running";
     pill = "已连接";
@@ -162,5 +198,14 @@ export function deriveControllerStatus(lines) {
     peer: info.bt_last_peer ?? "-",
     initStep: info.bt_init_step ?? "-",
     initError,
+    rawReadyValue: rawReady,
+    readyInferredValue: readyInferredFromPairing,
+    unstableValue: unstableInferredReady,
+    reconnectRecommendedValue: unstableInferredReady,
+    sendReportFailureCount,
+    lastSendReportStatus,
+    lastSendReportReason,
+    lastAclDisconnectReason,
+    lastDropReason: info.bt_last_drop_reason ?? "-",
   };
 }

--- a/apps/desktop/test/controller-status.test.ts
+++ b/apps/desktop/test/controller-status.test.ts
@@ -61,6 +61,36 @@ test("deriveControllerStatus prefers connected-ready progress over stale init er
   assert.equal(status?.initError, "btStart_failed");
 });
 
+test("deriveControllerStatus marks congested inferred-ready links as unstable", () => {
+  const status = deriveControllerStatus([
+    "INFO transport=classic-bt-uartswitchcon",
+    "INFO bt_profile=uartswitchcon-pro-controller",
+    "INFO bt_discoverable=false",
+    "INFO bt_auth_complete=false",
+    "INFO bt_connected=true",
+    "INFO bt_paired=true",
+    "INFO bt_ready_for_reports=false",
+    "INFO bt_send_report_failures=7236",
+    "INFO bt_last_send_report_status=1",
+    "INFO bt_last_send_report_reason=8",
+    "INFO bt_last_acl_disconnect_reason=19",
+    "INFO bt_init_step=discoverable",
+    "INFO bt_init_error=ESP_OK",
+  ]);
+
+  assert.ok(status);
+  assert.equal(status?.tone, "warning");
+  assert.equal(status?.pill, "不稳定");
+  assert.equal(status?.title, "连接容易断开");
+  assert.equal(status?.ready, "未就绪");
+  assert.equal(status?.readyValue, false);
+  assert.equal(status?.unstableValue, true);
+  assert.equal(status?.reconnectRecommendedValue, true);
+  assert.equal(status?.sendReportFailureCount, 7236);
+  assert.equal(status?.lastSendReportReason, 8);
+  assert.equal(status?.lastAclDisconnectReason, 19);
+});
+
 test("shouldReuseExistingControllerConnection keeps active bluetooth sessions intact", () => {
   assert.equal(
     shouldReuseExistingControllerConnection({
@@ -107,6 +137,17 @@ test("shouldReuseExistingControllerConnection keeps active bluetooth sessions in
     }),
     false,
   );
+  assert.equal(
+    shouldReuseExistingControllerConnection({
+      readyValue: false,
+      connectedValue: true,
+      authValue: false,
+      discoverableValue: false,
+      reconnectRecommendedValue: true,
+      unstableValue: true,
+    }),
+    false,
+  );
 });
 
 test("controller status updates also resync the controller action buttons", async () => {
@@ -123,5 +164,10 @@ test("controller status updates also resync the controller action buttons", asyn
   assert.match(
     appSource,
     /els\.controllerInfoButton\.addEventListener\("click", async \(\) => \{[\s\S]*await requestControllerStatus\(\)[\s\S]*shouldReuseExistingControllerConnection\(state\.controller\.status\)[\s\S]*runControllerCommands\(\["BT RESET", "I"\], "连接手柄"\)/u,
+  );
+
+  assert.match(
+    appSource,
+    /state\.controller\.status\.reconnectRecommendedValue === true[\s\S]*runControllerCommands\(\["BT RESET", "I"\], "自动恢复手柄连接"\)/u,
   );
 });

--- a/apps/desktop/test/execution-control.test.ts
+++ b/apps/desktop/test/execution-control.test.ts
@@ -1,0 +1,60 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+
+import type {
+  SerialSessionManager,
+  SerialSessionSnapshot,
+} from "../src/serial/sender.js";
+import { ManagedSerialSessionSender } from "../src/web/server.js";
+
+function makeDisconnectedSerialSessionSnapshot(): SerialSessionSnapshot {
+  return {
+    connected: false,
+    portPath: null,
+    baudRate: null,
+    busy: false,
+    idleTimeoutMs: 0,
+    lastUsedAt: null,
+  };
+}
+
+test("ManagedSerialSessionSender.stop interrupts a blocking ACK wait and disconnects the session", async () => {
+  let disconnectCalls = 0;
+  let readyToStop: (() => void) | null = null;
+  let resolveInterruptReady: (() => void) | null = null;
+  const interruptReady = new Promise<void>((resolve) => {
+    resolveInterruptReady = resolve;
+  });
+
+  const sessionManager = {
+    async send(_commands: string[], options: Parameters<SerialSessionManager["send"]>[1]): Promise<void> {
+      await new Promise<void>((_resolve, reject) => {
+        readyToStop = () => {
+          reject(new Error("Execution stopped."));
+        };
+        options.onInterruptReady?.(readyToStop);
+        resolveInterruptReady?.();
+      });
+    },
+    async disconnect(options: { force?: boolean } = {}): Promise<SerialSessionSnapshot> {
+      disconnectCalls += 1;
+      assert.equal(options.force, true);
+      return makeDisconnectedSerialSessionSnapshot();
+    },
+  } as unknown as SerialSessionManager;
+  const sender = new ManagedSerialSessionSender(sessionManager);
+  const sendPromise = sender.send(["P"], {
+    path: "COM1",
+    baudRate: 115200,
+    ackTimeoutMs: 2_000,
+    retries: 0,
+  });
+
+  await interruptReady;
+  assert.ok(readyToStop);
+
+  sender.stop();
+
+  await assert.rejects(sendPromise, /Execution stopped/u);
+  assert.equal(disconnectCalls, 1);
+});

--- a/apps/desktop/test/firmware-flash.test.ts
+++ b/apps/desktop/test/firmware-flash.test.ts
@@ -3,6 +3,8 @@ import { readFile } from "node:fs/promises";
 import test from "node:test";
 
 import {
+  formatMissingSelectedUploadPortMessage,
+  formatSelectedUploadPortFailureMessage,
   isUploadPortFailure,
   summarizePlatformIoFailure,
 } from "../src/web/server.js";
@@ -34,6 +36,23 @@ test("isUploadPortFailure recognizes upload-port-specific serial failures", () =
   assert.equal(
     isUploadPortFailure("Compiling .pio/build/esp32dev_wireless/src/main.cpp.o"),
     false,
+  );
+});
+
+test("firmware flash keeps the user on the selected upload port when that port disappears", () => {
+  assert.equal(
+    formatMissingSelectedUploadPortMessage("COM7"),
+    "Selected port COM7 is no longer detected. Reconnect the board or choose a different port and retry.",
+  );
+});
+
+test("firmware flash reports port-specific upload failures without switching to auto-detect", () => {
+  assert.equal(
+    formatSelectedUploadPortFailureMessage(
+      "COM7",
+      "could not open port 'COM7': Permission denied",
+    ),
+    "Upload failed on the selected port COM7. could not open port 'COM7': Permission denied Reconnect the board, make sure no other app is using the port, or choose a different port and retry.",
   );
 });
 

--- a/apps/desktop/test/firmware-flash.test.ts
+++ b/apps/desktop/test/firmware-flash.test.ts
@@ -1,4 +1,5 @@
 import assert from "node:assert/strict";
+import { readFile } from "node:fs/promises";
 import test from "node:test";
 
 import {
@@ -33,5 +34,33 @@ test("isUploadPortFailure recognizes upload-port-specific serial failures", () =
   assert.equal(
     isUploadPortFailure("Compiling .pio/build/esp32dev_wireless/src/main.cpp.o"),
     false,
+  );
+});
+
+test("esp32 wireless firmware keeps a 2MB-compatible upload header for generic boards", async () => {
+  const platformioSource = await readFile(
+    new URL("../../../firmware/esp32/platformio.ini", import.meta.url),
+    "utf8",
+  );
+
+  assert.match(
+    platformioSource,
+    /\[env:esp32dev_wireless\][\s\S]*board_build\.esp-idf\.sdkconfig_path\s*=\s*sdkconfig\.esp32dev_wireless[\s\S]*board_upload\.flash_size\s*=\s*2MB/u,
+  );
+});
+
+test("controller firmware keeps bluetooth identity stable and waits for host HID open after auth", async () => {
+  const firmwareSource = await readFile(
+    new URL("../../../firmware/esp32/src/classic_bt_controller_transport.cpp", import.meta.url),
+    "utf8",
+  );
+
+  assert.match(
+    firmwareSource,
+    /deriveDeterministicBaseMac[\s\S]*source=%s/u,
+  );
+  assert.doesNotMatch(
+    firmwareSource,
+    /ESP_BT_GAP_AUTH_CMPL_EVT[\s\S]*attemptVirtualCablePlug\(lastPeerAddress_, "auth-complete"\)/u,
   );
 });

--- a/apps/desktop/test/recovery.test.ts
+++ b/apps/desktop/test/recovery.test.ts
@@ -289,6 +289,52 @@ test("recovery cleanup removes expired completed sessions and orphaned command f
   }
 });
 
+test("recovery sessions keep unique job ids even within the same millisecond", async () => {
+  const recoverySessionsRoot = await mkdtemp(path.join(os.tmpdir(), "friendmaker-recovery-unique-"));
+  const profile = makeProfile({ canvasWidth: 5, canvasHeight: 1 });
+  const pixelMap = makePixelMap(5, 1, [
+    { x: 2, y: 0, colorIndex: 0, colorHex: "#000000" },
+  ]);
+  const scanlinePlan = generateScanlinePlan(pixelMap, profile);
+  const commands = serializeCommands(scanlinePlan.commands);
+  const store = new RecoverySessionStore(recoverySessionsRoot);
+  const originalNow = Date.now;
+
+  Date.now = () => 1_714_816_800_000;
+
+  try {
+    const first = await store.createSession({
+      commands,
+      resumePlan: scanlinePlan.resumePlan,
+      sourceLabel: "same-image.png",
+      profileSummary: makeRecoveryProfileSummary(profile),
+      serialOptions: {
+        baudRate: profile.baudRate,
+        ackTimeoutMs: profile.ackTimeoutMs,
+        retries: profile.commandRetryCount,
+      },
+    });
+    const second = await store.createSession({
+      commands,
+      resumePlan: scanlinePlan.resumePlan,
+      sourceLabel: "same-image.png",
+      profileSummary: makeRecoveryProfileSummary(profile),
+      serialOptions: {
+        baudRate: profile.baudRate,
+        ackTimeoutMs: profile.ackTimeoutMs,
+        retries: profile.commandRetryCount,
+      },
+    });
+    const sessions = await store.listSessions();
+
+    assert.notEqual(first.jobId, second.jobId);
+    assert.equal(sessions.length, 2);
+  } finally {
+    Date.now = originalNow;
+    await rm(recoverySessionsRoot, { recursive: true, force: true });
+  }
+});
+
 test("startup cleanup converts stale running sessions into recoverable sessions", async () => {
   const recoverySessionsRoot = await mkdtemp(path.join(os.tmpdir(), "friendmaker-recovery-startup-"));
   const profile = makeProfile({ canvasWidth: 5, canvasHeight: 1 });
@@ -466,6 +512,78 @@ test("recovery session API persists visible files across restarts and can discar
 
     if (secondServer) {
       await secondServer.close();
+    }
+
+    await rm(recoverySessionsRoot, { recursive: true, force: true });
+  }
+});
+
+test("execution reset keeps unfinished recovery sessions recoverable", async () => {
+  const recoverySessionsRoot = await mkdtemp(path.join(os.tmpdir(), "friendmaker-recovery-reset-"));
+  const profile = makeProfile({ canvasWidth: 6, canvasHeight: 1 });
+  const pixelMap = makePixelMap(6, 1, [
+    { x: 1, y: 0, colorIndex: 0, colorHex: "#000000" },
+    { x: 4, y: 0, colorIndex: 0, colorHex: "#000000" },
+  ]);
+  const scanlinePlan = generateScanlinePlan(pixelMap, profile);
+  const commands = serializeCommands(scanlinePlan.commands);
+  const requestBody = {
+    target: "simulate",
+    commands,
+    ackDelayMs: 200,
+    resumePlan: scanlinePlan.resumePlan,
+    sourceLabel: "reset-demo.png",
+    profileSummary: makeRecoveryProfileSummary(profile),
+  };
+
+  let server: Awaited<ReturnType<typeof startWebServer>> | null = null;
+
+  try {
+    server = await startWebServer({ port: 0, recoverySessionsRoot });
+    const startResponse = await fetch(`${server.url}/api/execution/start`, {
+      method: "POST",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify(requestBody),
+    });
+    assert.equal(startResponse.ok, true);
+    const startPayload = (await startResponse.json()) as {
+      recoverySession?: { jobId: string };
+    };
+
+    assert.ok(startPayload.recoverySession);
+    await new Promise((resolve) => setTimeout(resolve, 10));
+
+    const resetResponse = await fetch(`${server.url}/api/execution/reset`, {
+      method: "POST",
+    });
+    assert.equal(resetResponse.ok, true);
+    const resetPayload = (await resetResponse.json()) as {
+      execution?: { status?: string };
+    };
+
+    assert.equal(resetPayload.execution?.status, "idle");
+
+    const sessionsResponse = await fetch(`${server.url}/api/recovery/sessions`);
+    assert.equal(sessionsResponse.ok, true);
+    const sessionsPayload = (await sessionsResponse.json()) as {
+      sessions?: Array<{
+        jobId: string;
+        status: string;
+        completedCommands: number;
+        nextResumeSegmentIndex: number | null;
+      }>;
+    };
+    const session = sessionsPayload.sessions?.find(
+      (item) => item.jobId === startPayload.recoverySession?.jobId,
+    );
+
+    assert.ok(session);
+    assert.equal(session.status, "recoverable");
+    assert.ok(session.completedCommands < commands.length);
+    assert.notEqual(session.nextResumeSegmentIndex, null);
+  } finally {
+    if (server) {
+      await server.close();
     }
 
     await rm(recoverySessionsRoot, { recursive: true, force: true });

--- a/apps/desktop/test/three-layer-fix.test.ts
+++ b/apps/desktop/test/three-layer-fix.test.ts
@@ -10,7 +10,10 @@ import { pixelizeImage } from "../src/image/pixelize.js";
 import { renderPreviewToBuffer } from "../src/image/renderPreview.js";
 import { generateScanlineCommands } from "../src/path/scanline.js";
 import { serializeCommands } from "../src/protocol/serializer.js";
-import { getAckTimeoutForCommand } from "../src/serial/sender.js";
+import {
+  getAckTimeoutForCommand,
+  isCongestedControllerSendReportLine,
+} from "../src/serial/sender.js";
 import { SimulatedAckSender } from "../src/simulator/sender.js";
 import type { BrushSize, DrawingMask, DrawingProfile, Pixel, PixelMap, RawImageData } from "../src/types.js";
 
@@ -363,4 +366,25 @@ test("controller input report failures are not retried", async () => {
   );
 
   assert.equal(lines.some((line) => line.startsWith("WARN retry")), false);
+});
+
+test("congested controller send-report warnings are recognized as execution-fatal", () => {
+  assert.equal(
+    isCongestedControllerSendReportLine(
+      "WARN bt hid event=send-report status=1 reason=8 report=48",
+    ),
+    true,
+  );
+  assert.equal(
+    isCongestedControllerSendReportLine(
+      "WARN bt hid event=send-report status=1 reason=8 report=33",
+    ),
+    false,
+  );
+  assert.equal(
+    isCongestedControllerSendReportLine(
+      "INFO bt hid event=send-report status=1 reason=8 report=48",
+    ),
+    false,
+  );
 });

--- a/firmware/esp32/platformio.ini
+++ b/firmware/esp32/platformio.ini
@@ -9,11 +9,14 @@ monitor_speed = 115200
 [env:esp32dev_wireless]
 board = esp32dev
 framework = arduino, espidf
+board_build.esp-idf.sdkconfig_path = sdkconfig.esp32dev_wireless
+board_upload.flash_size = 2MB
 build_flags =
   -DSWITCH_AUTO_DRAW_USE_CLASSIC_BT=1
 
 # Default target for generic ESP32-WROOM-32 / ESP-32S dev boards.
-# This matches the Bluetooth Classic route used for Switch controller work.
+# Keep the image header explicit at 2MB so smaller flash clones do not boot
+# with a stale 4MB expectation warning during wireless-controller pairing work.
 
 [env:nodemcu_32s_wireless]
 board = nodemcu-32s

--- a/firmware/esp32/src/classic_bt_controller_transport.cpp
+++ b/firmware/esp32/src/classic_bt_controller_transport.cpp
@@ -31,6 +31,10 @@ constexpr uint8_t kStickMax = 255;
 constexpr uint8_t kHidErrCongested = 8;
 constexpr uint16_t kHidCongestionRetryDelayMs = HID_REPEAT_INTERVAL_MS;
 constexpr uint16_t kHidCongestionRetryBudgetMs = HID_REPEAT_INTERVAL_MS * 4;
+constexpr uint16_t kIdleDisconnectedReportIntervalMs = 100;
+constexpr uint16_t kIdlePrePairingReportIntervalMs = 30;
+constexpr uint16_t kIdleCongestedReportIntervalMs = 45;
+constexpr uint16_t kIdleConnectedReportIntervalMs = 15;
 
 uint8_t kHidDescriptor[] = {
     0x05, 0x01, 0x09, 0x05, 0xa1, 0x01, 0x06, 0x01, 0xff, 0x85, 0x21, 0x09,
@@ -387,6 +391,7 @@ void ClassicBtControllerTransport::clearConnectionState() {
   lastSendReportReason_ = 0;
   lastSendReportId_ = 0;
   reportCongested_ = false;
+  consecutiveSendReportFailures_ = 0;
   sendReportFailureCount_ = 0;
   lastDropReason_ = "none";
 }
@@ -563,13 +568,29 @@ void ClassicBtControllerTransport::ensureSendTask() {
       0);
 }
 
+uint16_t ClassicBtControllerTransport::idleSendIntervalMs() const {
+  if (!connected_ && !paired_) {
+    return kIdleDisconnectedReportIntervalMs;
+  }
+
+  if (reportCongested_ || consecutiveSendReportFailures_ >= 3) {
+    return kIdleCongestedReportIntervalMs;
+  }
+
+  if (!paired_ || !authComplete_) {
+    return kIdlePrePairingReportIntervalMs;
+  }
+
+  return kIdleConnectedReportIntervalMs;
+}
+
 void ClassicBtControllerTransport::sendTaskTrampoline(void *param) {
   auto *transport = static_cast<ClassicBtControllerTransport *>(param);
   while (true) {
     if (!transport->explicitInputActive_) {
       transport->sendCurrentInputReport(false);
     }
-    vTaskDelay(pdMS_TO_TICKS((transport->connected_ || transport->paired_) ? 15 : 100));
+    vTaskDelay(pdMS_TO_TICKS(transport->idleSendIntervalMs()));
   }
 }
 
@@ -627,6 +648,8 @@ void ClassicBtControllerTransport::enterReconnectableState(const char *reason) {
   pairingComplete_ = false;
   paired_ = false;
   discoverable_ = true;
+  reportCongested_ = false;
+  consecutiveSendReportFailures_ = 0;
   lastDropReason_ = reason;
   clearInputs();
 
@@ -736,6 +759,9 @@ bool ClassicBtControllerTransport::sendCurrentInputReport(bool logFailure) {
       const_cast<uint8_t *>(payload));
   if (err != ESP_OK) {
     sendReportFailureCount_ += 1;
+    if (consecutiveSendReportFailures_ < UINT8_MAX) {
+      consecutiveSendReportFailures_ += 1;
+    }
     lastSendReportStatus_ = static_cast<int>(err);
     lastSendReportReason_ = 0;
     lastSendReportId_ = 0x30;
@@ -1037,6 +1063,8 @@ void ClassicBtControllerTransport::handleHidEvent(int event, void *rawParam) {
                    param->open.conn_status == ESP_HIDD_CONN_STATE_CONNECTED;
       readyForReports_ = connected_ && appRegistered_ && hidReady_;
       discoverable_ = !connected_;
+      reportCongested_ = false;
+      consecutiveSendReportFailures_ = 0;
       if (connected_) {
         std::memcpy(lastPeerAddress_, param->open.bd_addr, sizeof(lastPeerAddress_));
         hasPeerAddress_ = true;
@@ -1062,6 +1090,11 @@ void ClassicBtControllerTransport::handleHidEvent(int event, void *rawParam) {
     case ESP_HIDD_SEND_REPORT_EVT:
       if (param->send_report.status != ESP_HIDD_SUCCESS) {
         sendReportFailureCount_ += 1;
+        if (consecutiveSendReportFailures_ < UINT8_MAX) {
+          consecutiveSendReportFailures_ += 1;
+        }
+      } else {
+        consecutiveSendReportFailures_ = 0;
       }
       lastSendReportStatus_ = param->send_report.status;
       lastSendReportReason_ = param->send_report.reason;

--- a/firmware/esp32/src/classic_bt_controller_transport.cpp
+++ b/firmware/esp32/src/classic_bt_controller_transport.cpp
@@ -73,6 +73,27 @@ bool isIgnorableBluetoothError(esp_err_t err) {
   return err == ESP_OK || err == ESP_ERR_INVALID_STATE;
 }
 
+bool deriveDeterministicBaseMac(uint8_t baseMac[6]) {
+  uint8_t factoryMac[6] = {};
+  const esp_err_t err = esp_efuse_mac_get_default(factoryMac);
+
+  if (err != ESP_OK) {
+    Serial.printf("WARN efuse_mac_get_default failed err=%s\n", esp_err_to_name(err));
+    return false;
+  }
+
+  // Keep the Nintendo-like OUI we already expose to Switch, but derive the
+  // device-specific suffix from the chip eFuse so the controller identity stays
+  // stable even if the user reflashes or the NVS namespace is rebuilt.
+  baseMac[0] = 0xD4;
+  baseMac[1] = 0xF0;
+  baseMac[2] = 0x57;
+  baseMac[3] = factoryMac[3];
+  baseMac[4] = factoryMac[4];
+  baseMac[5] = factoryMac[5];
+  return true;
+}
+
 String formatBluetoothAddress(const uint8_t address[6]) {
   char buffer[18];
   std::snprintf(
@@ -221,38 +242,49 @@ bool ClassicBtControllerTransport::initializeNvsAndBaseAddress() {
     return false;
   }
 
+  uint8_t baseMac[6] = {};
+  const char *baseMacSource = "efuse-derived";
+  bool shouldPersistDerivedMac = false;
   nvs_handle handle;
   err = nvs_open("storage", NVS_READWRITE, &handle);
-  if (err != ESP_OK) {
-    Serial.printf("WARN nvs_open failed err=%s\n", esp_err_to_name(err));
-    return false;
+  if (err == ESP_OK) {
+    size_t size = sizeof(baseMac);
+    err = nvs_get_blob(handle, "mac_addr", baseMac, &size);
+    if (err == ESP_OK && size == sizeof(baseMac)) {
+      baseMacSource = "nvs";
+    } else {
+      if (!deriveDeterministicBaseMac(baseMac)) {
+        nvs_close(handle);
+        return false;
+      }
+      shouldPersistDerivedMac = true;
+    }
+  } else {
+    Serial.printf(
+        "WARN nvs_open failed err=%s; using deterministic base mac fallback\n",
+        esp_err_to_name(err));
+    if (!deriveDeterministicBaseMac(baseMac)) {
+      return false;
+    }
   }
 
-  uint8_t baseMac[6] = {};
-  size_t size = sizeof(baseMac);
-  err = nvs_get_blob(handle, "mac_addr", baseMac, &size);
-  if (err != ESP_OK || size != sizeof(baseMac)) {
-    baseMac[0] = 0xD4;
-    baseMac[1] = 0xF0;
-    baseMac[2] = 0x57;
-    for (size_t index = 3; index < sizeof(baseMac); index += 1) {
-      baseMac[index] = static_cast<uint8_t>(esp_random() & 0xFF);
-    }
+  if (shouldPersistDerivedMac) {
     err = nvs_set_blob(handle, "mac_addr", baseMac, sizeof(baseMac));
     if (err != ESP_OK) {
-      nvs_close(handle);
       Serial.printf("WARN nvs_set_blob failed err=%s\n", esp_err_to_name(err));
-      return false;
-    }
-    err = nvs_commit(handle);
-    if (err != ESP_OK) {
-      nvs_close(handle);
-      Serial.printf("WARN nvs_commit failed err=%s\n", esp_err_to_name(err));
-      return false;
+    } else {
+      err = nvs_commit(handle);
+      if (err != ESP_OK) {
+        Serial.printf("WARN nvs_commit failed err=%s\n", esp_err_to_name(err));
+      }
     }
   }
 
-  nvs_close(handle);
+  if (baseMacSource == "nvs") {
+    nvs_close(handle);
+  } else if (err == ESP_OK || shouldPersistDerivedMac) {
+    nvs_close(handle);
+  }
 
   err = esp_base_mac_addr_set(baseMac);
   if (err != ESP_OK) {
@@ -261,13 +293,14 @@ bool ClassicBtControllerTransport::initializeNvsAndBaseAddress() {
   }
 
   Serial.printf(
-      "INFO bt base_mac=%02X:%02X:%02X:%02X:%02X:%02X\n",
+      "INFO bt base_mac=%02X:%02X:%02X:%02X:%02X:%02X source=%s\n",
       baseMac[0],
       baseMac[1],
       baseMac[2],
       baseMac[3],
       baseMac[4],
-      baseMac[5]);
+      baseMac[5],
+      baseMacSource);
   return true;
 }
 
@@ -994,7 +1027,9 @@ void ClassicBtControllerTransport::handleGapEvent(int event, void *rawParam) {
       if (param->auth_cmpl.stat == ESP_BT_STATUS_SUCCESS) {
         std::memcpy(lastPeerAddress_, param->auth_cmpl.bda, sizeof(lastPeerAddress_));
         hasPeerAddress_ = true;
-        attemptVirtualCablePlug(lastPeerAddress_, "auth-complete");
+        // Let Switch initiate the HID control channel after authentication.
+        // Proactively opening a virtual cable here can race with the host's own
+        // incoming CTRL connection and trigger invalid-state rejects.
       }
       break;
     case ESP_BT_GAP_MODE_CHG_EVT:

--- a/firmware/esp32/src/classic_bt_controller_transport.h
+++ b/firmware/esp32/src/classic_bt_controller_transport.h
@@ -24,6 +24,7 @@ class ClassicBtControllerTransport : public ControllerTransport {
   void setLeftStickFromVector(int x, int y);
   void updateInputReport();
   void ensureSendTask();
+  uint16_t idleSendIntervalMs() const;
   bool isHidReportChannelOpen() const;
   bool isControllerInputReady() const;
   bool sendCurrentInputReport(bool logFailure);
@@ -79,6 +80,7 @@ class ClassicBtControllerTransport : public ControllerTransport {
   uint8_t lastSendReportReason_ = 0;
   uint8_t lastSendReportId_ = 0;
   bool reportCongested_ = false;
+  uint8_t consecutiveSendReportFailures_ = 0;
   uint32_t sendReportFailureCount_ = 0;
   const char *lastDropReason_ = "none";
 };


### PR DESCRIPTION
## Summary
- stabilize the controller reconnect flow after HID congestion
- improve Switch pairing stability on 2MB ESP32 boards
- re-open these changes on a clean feature branch after reverting the accidental push to `main`

## Notes
- `main` has already been rolled back with commit `d55a18c`
- this PR replays the original work as two fresh commits on top of the reverted `main`

closes https://github.com/zhouxiyu1997/friendmaker/issues/26