### PR TITLE
Codex/bt input stability fix

### DIFF
--- a/apps/desktop/src/serial/sender.ts
+++ b/apps/desktop/src/serial/sender.ts
@@ -311,9 +311,48 @@ export function getAckTimeoutForCommand(
   timing: InputTiming = DEFAULT_SAFE_INPUT_TIMING,
 ): number {
   const trimmed = command.trim();
+  const simplePressTimeoutMs = 1_000 + timing.buttonPressMs + timing.inputDelayMs;
+  const boundedTimeout = (computedTimeoutMs: number) => Math.max(baseTimeoutMs, computedTimeoutMs);
 
   if (trimmed.startsWith("CFG INPUT ")) {
     return baseTimeoutMs;
+  }
+
+  if (trimmed === "P" || trimmed.startsWith("BTN ")) {
+    return boundedTimeout(simplePressTimeoutMs);
+  }
+
+  if (trimmed.startsWith("HOLD ")) {
+    const match = /^HOLD\s+\S+\s+(\d+)$/u.exec(trimmed);
+
+    if (!match?.[1]) {
+      return boundedTimeout(simplePressTimeoutMs);
+    }
+
+    const holdMs = Number.parseInt(match[1], 10);
+    return boundedTimeout(1_000 + holdMs + timing.inputDelayMs);
+  }
+
+  if (trimmed.startsWith("TAP ")) {
+    const match = /^TAP\s+\S+\s+(\d+)$/u.exec(trimmed);
+
+    if (!match?.[1]) {
+      return boundedTimeout(simplePressTimeoutMs);
+    }
+
+    const count = Number.parseInt(match[1], 10);
+    return boundedTimeout(1_000 + count * (timing.buttonPressMs + timing.inputDelayMs));
+  }
+
+  if (trimmed.startsWith("STICK ")) {
+    const match = /^STICK\s+(-?\d+)\s+(-?\d+)\s+(\d+)$/u.exec(trimmed);
+
+    if (!match?.[3]) {
+      return boundedTimeout(simplePressTimeoutMs);
+    }
+
+    const holdMs = Number.parseInt(match[3], 10);
+    return boundedTimeout(1_000 + holdMs + timing.inputDelayMs);
   }
 
   if (trimmed === "H") {

--- a/apps/desktop/src/web/server.ts
+++ b/apps/desktop/src/web/server.ts
@@ -416,6 +416,11 @@ interface LoggedError extends Error {
   logged?: boolean;
 }
 
+interface ExecutionError extends Error {
+  lines?: string[];
+  session?: SerialSessionSnapshot;
+}
+
 function createIdleFirmwareFlashState(): FirmwareFlashSnapshot {
   return {
     status: "idle",
@@ -439,6 +444,14 @@ function markLogged(error: Error): LoggedError {
   const loggedError = error as LoggedError;
   loggedError.logged = true;
   return loggedError;
+}
+
+function withExecutionContext(error: unknown, lines: string[]): ExecutionError {
+  const executionError =
+    error instanceof Error ? (error as ExecutionError) : (new Error(String(error)) as ExecutionError);
+  executionError.lines = [...lines];
+  executionError.session = serialSessionManager.snapshot();
+  return executionError;
 }
 
 export function isUploadPortFailure(message: string): boolean {
@@ -1117,38 +1130,44 @@ async function executeCommands(body: {
   const retries = body.retries ?? 1;
   const lines: string[] = [`INFO target=${target} commands=${body.commands.length}`];
 
-  if (target === "serial") {
-    if (!body.portPath) {
-      throw new Error("Missing portPath.");
+  try {
+    if (target === "serial") {
+      if (!body.portPath) {
+        throw new Error("Missing portPath.");
+      }
+
+      if (isManagedExecutionActive(managedExecution.status)) {
+        throw new Error("Drawing execution is already running.");
+      }
+
+      lines.push(`INFO port=${body.portPath} baud=${body.baudRate ?? 115200}`);
+
+      await serialSessionManager.send(body.commands, {
+        path: body.portPath,
+        baudRate: body.baudRate ?? 115200,
+        ackTimeoutMs,
+        retries,
+        onDeviceLine: (line) => {
+          lines.push(line);
+        },
+      });
+    } else {
+      const sender = new SimulatedAckSender();
+
+      await sender.send(body.commands, {
+        ackTimeoutMs,
+        retries,
+        ackDelayMs: body.ackDelayMs ?? 0,
+        ...(body.errorAtCommand !== undefined ? { errorAtCommand: body.errorAtCommand } : {}),
+        onDeviceLine: (line) => {
+          lines.push(line);
+        },
+      });
     }
-
-    if (isManagedExecutionActive(managedExecution.status)) {
-      throw new Error("Drawing execution is already running.");
-    }
-
-    lines.push(`INFO port=${body.portPath} baud=${body.baudRate ?? 115200}`);
-
-    await serialSessionManager.send(body.commands, {
-      path: body.portPath,
-      baudRate: body.baudRate ?? 115200,
-      ackTimeoutMs,
-      retries,
-      onDeviceLine: (line) => {
-        lines.push(line);
-      },
-    });
-  } else {
-    const sender = new SimulatedAckSender();
-
-    await sender.send(body.commands, {
-      ackTimeoutMs,
-      retries,
-      ackDelayMs: body.ackDelayMs ?? 0,
-      ...(body.errorAtCommand !== undefined ? { errorAtCommand: body.errorAtCommand } : {}),
-      onDeviceLine: (line) => {
-        lines.push(line);
-      },
-    });
+  } catch (error) {
+    const message = error instanceof Error ? error.message : String(error);
+    lines.push(`WARN execute failed message=${message}`);
+    throw withExecutionContext(error, lines);
   }
 
   lines.push("INFO completed");
@@ -1524,7 +1543,12 @@ async function handleExecute(request: IncomingMessage, response: ServerResponse)
     json(response, 200, await executeCommands(body));
   } catch (error) {
     const message = error instanceof Error ? error.message : String(error);
-    json(response, 400, { error: message, session: serialSessionManager.snapshot() });
+    const executionError = error as ExecutionError;
+    json(response, 400, {
+      error: message,
+      lines: executionError.lines ?? [],
+      session: executionError.session ?? serialSessionManager.snapshot(),
+    });
   }
 }
 
@@ -1865,7 +1889,12 @@ async function handleSimulate(request: IncomingMessage, response: ServerResponse
     );
   } catch (error) {
     const message = error instanceof Error ? error.message : String(error);
-    json(response, 400, { error: message, session: serialSessionManager.snapshot() });
+    const executionError = error as ExecutionError;
+    json(response, 400, {
+      error: message,
+      lines: executionError.lines ?? [],
+      session: executionError.session ?? serialSessionManager.snapshot(),
+    });
   }
 }
 

--- a/apps/desktop/src/web/static/app.js
+++ b/apps/desktop/src/web/static/app.js
@@ -85,7 +85,7 @@ const state = {
     },
     profile: {
       baudRate: 115200,
-      ackTimeoutMs: 5000,
+      ackTimeoutMs: 2000,
       commandRetryCount: 1,
       templateId: "none",
       templateLabel: "无模板（正方形）",
@@ -833,7 +833,7 @@ function applyGeneratedStudioPayload(payload) {
     : [];
   state.studio.profile = {
     baudRate: payload.profile.baudRate ?? 115200,
-    ackTimeoutMs: payload.profile.ackTimeoutMs ?? 5000,
+    ackTimeoutMs: payload.profile.ackTimeoutMs ?? 2000,
     commandRetryCount: payload.profile.commandRetryCount ?? 1,
     templateId: payload.profile.templateId ?? state.studio.templateId,
     templateLabel: payload.profile.templateLabel ?? state.studio.templateLabel,
@@ -2247,13 +2247,15 @@ async function requestControllerStatus({ logErrors = false } = {}) {
       }),
     });
     const payload = await response.json();
+    applySerialSessionSnapshot(payload.session);
 
     if (!response.ok) {
-      applySerialSessionSnapshot(payload.session);
+      if (logErrors) {
+        appendExecutionLines(els.controllerLogOutput, payload.lines);
+      }
       throw new Error(payload.error ?? "读取手柄状态失败");
     }
 
-    applySerialSessionSnapshot(payload.session);
     updateControllerStatusFromLines(payload.lines ?? []);
     return true;
   } catch (error) {
@@ -2741,6 +2743,10 @@ function syncControllerUi() {
   renderSerialSessionStatus();
 }
 
+function appendExecutionLines(logTarget, lines) {
+  (lines ?? []).forEach((line) => appendLog(logTarget, `[device] ${line}`));
+}
+
 async function runExecution({
   commands,
   target,
@@ -2769,15 +2775,15 @@ async function runExecution({
       }),
     });
     const payload = await response.json();
+    applySerialSessionSnapshot(payload.session);
 
     if (!response.ok) {
-      applySerialSessionSnapshot(payload.session);
+      appendExecutionLines(logTarget, payload.lines);
       throw new Error(payload.error ?? "执行失败");
     }
 
-    applySerialSessionSnapshot(payload.session);
     appendLog(logTarget, `${successLabel}完成：${payload.totalCommands} 条命令，目标 ${payload.target}`);
-    (payload.lines ?? []).forEach((line) => appendLog(logTarget, `[device] ${line}`));
+    appendExecutionLines(logTarget, payload.lines);
     return payload;
   } catch (error) {
     appendLog(logTarget, `执行失败：${getErrorMessage(error)}`);

--- a/firmware/esp32/src/classic_bt_controller_transport.cpp
+++ b/firmware/esp32/src/classic_bt_controller_transport.cpp
@@ -199,6 +199,12 @@ ClassicBtControllerTransport *ClassicBtControllerTransport::instance_ = nullptr;
 
 void ClassicBtControllerTransport::begin() {
   instance_ = this;
+  if (inputReportSendMutex_ == nullptr) {
+    inputReportSendMutex_ = xSemaphoreCreateRecursiveMutex();
+    if (inputReportSendMutex_ == nullptr) {
+      Serial.println("WARN bt input-report mutex create failed");
+    }
+  }
   clearInputs();
   if (!initializeClassicBluetooth()) {
     Serial.println("WARN bt begin failed");
@@ -375,6 +381,7 @@ void ClassicBtControllerTransport::clearConnectionState() {
   stackStarted_ = false;
   timer_ = 0;
   explicitInputActive_ = false;
+  resetInputReportTracking();
   initStep_ = "idle";
   initError_ = "none";
   ignoredReportCount_ = 0;
@@ -386,7 +393,6 @@ void ClassicBtControllerTransport::clearConnectionState() {
   lastSendReportStatus_ = -1;
   lastSendReportReason_ = 0;
   lastSendReportId_ = 0;
-  reportCongested_ = false;
   sendReportFailureCount_ = 0;
   lastDropReason_ = "none";
 }
@@ -575,7 +581,9 @@ void ClassicBtControllerTransport::sendTaskTrampoline(void *param) {
 
 bool ClassicBtControllerTransport::pressButtons(
     uint32_t buttonsMask, uint16_t holdMs, uint16_t settleMs) {
-  explicitInputActive_ = true;
+  if (!beginExplicitInput()) {
+    return false;
+  }
   setButtonBits(buttonsMask);
   updateInputReport();
   bool ok = repeatCurrentInputReport(holdMs, true);
@@ -583,13 +591,15 @@ bool ClassicBtControllerTransport::pressButtons(
   if (!repeatCurrentInputReport(settleMs, true)) {
     ok = false;
   }
-  explicitInputActive_ = false;
+  endExplicitInput();
   return ok;
 }
 
 bool ClassicBtControllerTransport::moveDirection(
     int x, int y, uint16_t holdMs, uint16_t settleMs) {
-  explicitInputActive_ = true;
+  if (!beginExplicitInput()) {
+    return false;
+  }
   buttonsRight_ = 0;
   buttonsShared_ = 0;
   buttonsLeft_ = 0;
@@ -600,7 +610,7 @@ bool ClassicBtControllerTransport::moveDirection(
   if (!repeatCurrentInputReport(settleMs, true)) {
     ok = false;
   }
-  explicitInputActive_ = false;
+  endExplicitInput();
   return ok;
 }
 
@@ -711,29 +721,48 @@ bool ClassicBtControllerTransport::isControllerInputReady() const {
   return isHidReportChannelOpen() && paired_;
 }
 
-bool ClassicBtControllerTransport::sendCurrentInputReport(bool logFailure) {
+bool ClassicBtControllerTransport::sendCurrentInputReport(bool logFailure, bool waitForSendEvent) {
   readyForReports_ = isHidReportChannelOpen();
 
   if (!readyForReports_) {
     if (logFailure) {
-      Serial.printf("WARN bt report skipped reason=not-ready connected=%s paired=%s\n",
-                    boolName(connected_),
-                    boolName(paired_));
+      Serial.printf(
+          "WARN bt report skipped reason=not-ready connected=%s paired=%s\n",
+          boolName(connected_),
+          boolName(paired_));
     }
     return false;
   }
 
   updateInputReport();
 
+  const bool shouldWaitForSendEvent = waitForSendEvent && paired_;
+  uint32_t expectedEventCount = 0;
   const bool shouldSendFullReport = connected_ || paired_;
   const uint8_t *payload = shouldSendFullReport ? report30_ : dummyReport_;
   const size_t payloadLength = shouldSendFullReport ? sizeof(report30_) : sizeof(dummyReport_);
 
+  if (inputReportSendMutex_ != nullptr) {
+    xSemaphoreTakeRecursive(inputReportSendMutex_, portMAX_DELAY);
+  }
+
+  reportCongested_ = false;
   const esp_err_t err = esp_bt_hid_device_send_report(
       ESP_HIDD_REPORT_TYPE_INTRDATA,
       0x30,
       payloadLength,
       const_cast<uint8_t *>(payload));
+  if (err == ESP_OK) {
+    inputReportSubmitCount_ += 1;
+    if (shouldWaitForSendEvent) {
+      expectedEventCount = inputReportSubmitCount_;
+    }
+  }
+
+  if (inputReportSendMutex_ != nullptr) {
+    xSemaphoreGiveRecursive(inputReportSendMutex_);
+  }
+
   if (err != ESP_OK) {
     sendReportFailureCount_ += 1;
     lastSendReportStatus_ = static_cast<int>(err);
@@ -751,11 +780,91 @@ bool ClassicBtControllerTransport::sendCurrentInputReport(bool logFailure) {
   }
 
   timer_ = static_cast<uint8_t>(timer_ + 1);
-  return true;
+  return shouldWaitForSendEvent ? waitForInputReportAccepted(expectedEventCount, logFailure) : true;
 }
 
 bool ClassicBtControllerTransport::shouldRetryAfterTransientSendFailure() const {
-  return reportCongested_ && isHidReportChannelOpen() && paired_;
+  return reportCongested_ && isHidReportChannelOpen();
+}
+
+bool ClassicBtControllerTransport::waitForInputReportAccepted(
+    uint32_t expectedEventCount, bool logFailure) {
+  const uint32_t startedAt = millis();
+
+  while (inputReportSendEventCount_ < expectedEventCount) {
+    if (millis() - startedAt >= HID_SEND_REPORT_TIMEOUT_MS) {
+      if (logFailure) {
+        Serial.printf(
+            "WARN bt send_report timeout report=48 waited_ms=%u submitted=%lu completed=%lu\n",
+            HID_SEND_REPORT_TIMEOUT_MS,
+            static_cast<unsigned long>(inputReportSubmitCount_),
+            static_cast<unsigned long>(inputReportSendEventCount_));
+      }
+      return false;
+    }
+    delay(1);
+  }
+
+  if (lastInputReportStatus_ != ESP_HIDD_SUCCESS) {
+    if (logFailure) {
+      Serial.printf(
+          "WARN bt send_report rejected status=%d reason=%u report=%u\n",
+          lastInputReportStatus_,
+          lastInputReportReason_,
+          0x30);
+    }
+    return false;
+  }
+
+  return true;
+}
+
+bool ClassicBtControllerTransport::waitForInputReportDrain(uint32_t timeoutMs, bool logFailure) {
+  if (!paired_) {
+    return true;
+  }
+
+  const uint32_t startedAt = millis();
+  while (inputReportSendEventCount_ < inputReportSubmitCount_) {
+    if (millis() - startedAt >= timeoutMs) {
+      if (logFailure) {
+        Serial.printf(
+            "WARN bt send_report drain timeout waited_ms=%lu submitted=%lu completed=%lu\n",
+            static_cast<unsigned long>(timeoutMs),
+            static_cast<unsigned long>(inputReportSubmitCount_),
+            static_cast<unsigned long>(inputReportSendEventCount_));
+      }
+      return false;
+    }
+    delay(1);
+  }
+
+  return true;
+}
+
+bool ClassicBtControllerTransport::beginExplicitInput() {
+  explicitInputActive_ = true;
+
+  if (inputReportSendMutex_ == nullptr) {
+    return true;
+  }
+
+  xSemaphoreTakeRecursive(inputReportSendMutex_, portMAX_DELAY);
+  if (paired_ && inputReportSendEventCount_ < inputReportSubmitCount_) {
+    Serial.printf(
+        "INFO bt send_report drain skipped submitted=%lu completed=%lu\n",
+        static_cast<unsigned long>(inputReportSubmitCount_),
+        static_cast<unsigned long>(inputReportSendEventCount_));
+    inputReportSubmitCount_ = inputReportSendEventCount_;
+  }
+  return true;
+}
+
+void ClassicBtControllerTransport::endExplicitInput() {
+  if (inputReportSendMutex_ != nullptr) {
+    xSemaphoreGiveRecursive(inputReportSendMutex_);
+  }
+  explicitInputActive_ = false;
 }
 
 bool ClassicBtControllerTransport::repeatCurrentInputReport(
@@ -765,9 +874,7 @@ bool ClassicBtControllerTransport::repeatCurrentInputReport(
   bool loggedCongestionRetry = false;
 
   while (true) {
-    // Prefer the synchronous send result, but tolerate a brief burst of HID
-    // congestion before declaring the controller link unusable.
-    if (!sendCurrentInputReport(logFailure)) {
+    if (!sendCurrentInputReport(logFailure, false)) {
       if (shouldRetryAfterTransientSendFailure()) {
         if (congestionStartedAt == 0) {
           congestionStartedAt = millis();
@@ -802,6 +909,22 @@ bool ClassicBtControllerTransport::repeatCurrentInputReport(
   }
 
   return true;
+}
+
+void ClassicBtControllerTransport::resetInputReportTracking() {
+  inputReportSubmitCount_ = 0;
+  inputReportSendEventCount_ = 0;
+  lastInputReportStatus_ = -1;
+  lastInputReportReason_ = 0;
+  reportCongested_ = false;
+}
+
+void ClassicBtControllerTransport::markControllerPaired() {
+  if (!paired_) {
+    resetInputReportTracking();
+  }
+  paired_ = true;
+  pairingComplete_ = true;
 }
 
 bool ClassicBtControllerTransport::sendSubcommandReply(
@@ -941,14 +1064,12 @@ void ClassicBtControllerTransport::processIncomingReport(uint8_t reportId, uint1
     return;
   }
   if (data[9] == 48) {
-    paired_ = true;
-    pairingComplete_ = true;
+    markControllerPaired();
     sendSubcommandReply(0x21, kReply3001, sizeof(kReply3001), "reply3001");
     return;
   }
   if (data[9] == 33 && data[10] == 33) {
-    paired_ = true;
-    pairingComplete_ = true;
+    markControllerPaired();
     sendSubcommandReply(0x21, kReply3333, sizeof(kReply3333), "reply3333");
     return;
   }
@@ -1066,6 +1187,11 @@ void ClassicBtControllerTransport::handleHidEvent(int event, void *rawParam) {
       lastSendReportStatus_ = param->send_report.status;
       lastSendReportReason_ = param->send_report.reason;
       lastSendReportId_ = param->send_report.report_id;
+      if (param->send_report.report_id == 0x30) {
+        lastInputReportStatus_ = param->send_report.status;
+        lastInputReportReason_ = param->send_report.reason;
+        inputReportSendEventCount_ += 1;
+      }
       reportCongested_ = param->send_report.status != ESP_HIDD_SUCCESS &&
                          param->send_report.reason == kHidErrCongested;
       readyForReports_ = isHidReportChannelOpen();
@@ -1195,15 +1321,32 @@ void ClassicBtControllerTransport::updateInputReport() {}
 void ClassicBtControllerTransport::ensureSendTask() {}
 bool ClassicBtControllerTransport::isHidReportChannelOpen() const { return false; }
 bool ClassicBtControllerTransport::isControllerInputReady() const { return false; }
-bool ClassicBtControllerTransport::sendCurrentInputReport(bool logFailure) {
+bool ClassicBtControllerTransport::sendCurrentInputReport(bool logFailure, bool waitForSendEvent) {
+  (void)logFailure;
+  (void)waitForSendEvent;
+  return false;
+}
+bool ClassicBtControllerTransport::shouldRetryAfterTransientSendFailure() const { return false; }
+bool ClassicBtControllerTransport::waitForInputReportAccepted(
+    uint32_t expectedEventCount, bool logFailure) {
+  (void)expectedEventCount;
   (void)logFailure;
   return false;
 }
+bool ClassicBtControllerTransport::waitForInputReportDrain(uint32_t timeoutMs, bool logFailure) {
+  (void)timeoutMs;
+  (void)logFailure;
+  return false;
+}
+bool ClassicBtControllerTransport::beginExplicitInput() { return false; }
+void ClassicBtControllerTransport::endExplicitInput() {}
 bool ClassicBtControllerTransport::repeatCurrentInputReport(uint16_t durationMs, bool logFailure) {
   (void)durationMs;
   (void)logFailure;
   return false;
 }
+void ClassicBtControllerTransport::resetInputReportTracking() {}
+void ClassicBtControllerTransport::markControllerPaired() {}
 bool ClassicBtControllerTransport::sendSubcommandReply(
     uint8_t reportId, const uint8_t *data, size_t length, const char *label) {
   (void)reportId;

--- a/firmware/esp32/src/classic_bt_controller_transport.h
+++ b/firmware/esp32/src/classic_bt_controller_transport.h
@@ -1,6 +1,7 @@
 #pragma once
 
 #include "freertos/FreeRTOS.h"
+#include "freertos/semphr.h"
 #include "freertos/task.h"
 
 #include "controller_transport.h"
@@ -26,9 +27,15 @@ class ClassicBtControllerTransport : public ControllerTransport {
   void ensureSendTask();
   bool isHidReportChannelOpen() const;
   bool isControllerInputReady() const;
-  bool sendCurrentInputReport(bool logFailure);
+  bool sendCurrentInputReport(bool logFailure, bool waitForSendEvent = false);
   bool repeatCurrentInputReport(uint16_t durationMs, bool logFailure);
   bool shouldRetryAfterTransientSendFailure() const;
+  bool waitForInputReportAccepted(uint32_t expectedEventCount, bool logFailure);
+  bool waitForInputReportDrain(uint32_t timeoutMs, bool logFailure);
+  bool beginExplicitInput();
+  void endExplicitInput();
+  void resetInputReportTracking();
+  void markControllerPaired();
   bool sendSubcommandReply(uint8_t reportId, const uint8_t *data, size_t length, const char *label);
   bool attemptVirtualCablePlug(const uint8_t peerAddress[6], const char *reason);
   void enterReconnectableState(const char *reason);
@@ -65,8 +72,13 @@ class ClassicBtControllerTransport : public ControllerTransport {
   uint8_t rightStickY_ = 128;
   uint8_t report30_[48] = {};
   uint8_t dummyReport_[11] = {};
+  SemaphoreHandle_t inputReportSendMutex_ = nullptr;
   TaskHandle_t sendTaskHandle_ = nullptr;
   volatile bool explicitInputActive_ = false;
+  volatile uint32_t inputReportSubmitCount_ = 0;
+  volatile uint32_t inputReportSendEventCount_ = 0;
+  volatile int lastInputReportStatus_ = -1;
+  volatile uint8_t lastInputReportReason_ = 0;
   uint8_t lastPeerAddress_[6] = {};
   bool hasPeerAddress_ = false;
   uint32_t ignoredReportCount_ = 0;

--- a/firmware/esp32/src/config.h
+++ b/firmware/esp32/src/config.h
@@ -8,6 +8,7 @@ constexpr uint16_t CELL_MOVE_DURATION_MS = 80;
 constexpr uint16_t INPUT_DELAY_MS = 100;
 constexpr uint16_t BUTTON_PRESS_DURATION_MS = 100;
 constexpr uint16_t HID_REPEAT_INTERVAL_MS = 16;
+constexpr uint16_t HID_SEND_REPORT_TIMEOUT_MS = 400;
 constexpr uint8_t COLOR_PALETTE_SLOT_COUNT = 9;
 constexpr uint8_t COLOR_PALETTE_RESET_TO_BOTTOM_STEPS = 18;
 constexpr uint16_t COLOR_PALETTE_MENU_OPEN_SETTLE_MS = 180;


### PR DESCRIPTION
## Summary

Improve controller input stability and ACK diagnostics for Bluetooth-driven input.

## Changes

- add command-specific ACK timeout handling for `P`, `BTN`, `HOLD`, `TAP`, and `STICK` commands on the desktop sender
- preserve device execution lines and serial session snapshots on `/api/execute` failures so the web UI can surface richer error context
- update the controller UI to append device-side execution logs on failure and keep serial session state in sync
- add firmware-side input report send tracking and mutex protection in the classic Bluetooth transport
- reset and track Bluetooth input-report state more consistently across reconnect / pairing transitions
- introduce `HID_SEND_REPORT_TIMEOUT_MS` in firmware config for input-report diagnostics

## Testing

- `npm run test:desktop`
- `npm run check`
