### PR TITLE
Raise ack timeout floor and fix scanline routing

### DIFF
--- a/apps/desktop/src/config/defaultProfile.ts
+++ b/apps/desktop/src/config/defaultProfile.ts
@@ -85,6 +85,7 @@ function buildReferencePalette(): string[] {
 
 export const DEFAULT_PALETTE = buildReferencePalette();
 export const DEFAULT_OFFICIAL_PALETTE = OFFICIAL_PALETTE;
+export const DEFAULT_ACK_TIMEOUT_MS = 5_000;
 
 export const DEFAULT_PROFILE: DrawingProfile = {
   profileName: "switch-mono-256",
@@ -97,7 +98,7 @@ export const DEFAULT_PROFILE: DrawingProfile = {
   homeDuration: 1800,
   buttonPressDuration: 65,
   colorChangeDuration: 450,
-  ackTimeoutMs: 2_000,
+  ackTimeoutMs: DEFAULT_ACK_TIMEOUT_MS,
   commandRetryCount: 1,
   drawButton: "A",
   colorMode: "mono",

--- a/apps/desktop/src/config/loadProfile.ts
+++ b/apps/desktop/src/config/loadProfile.ts
@@ -1,7 +1,7 @@
 import { readFile } from "node:fs/promises";
 
 import type { DrawingProfile } from "../types.js";
-import { DEFAULT_PALETTE, DEFAULT_PROFILE } from "./defaultProfile.js";
+import { DEFAULT_ACK_TIMEOUT_MS, DEFAULT_PALETTE, DEFAULT_PROFILE } from "./defaultProfile.js";
 import { OFFICIAL_PALETTE } from "./officialPalette.js";
 
 const VALID_DRAWING_TOOLS = new Set<DrawingProfile["startTool"]>([
@@ -31,6 +31,10 @@ function toTool(value: unknown, fallback: DrawingProfile["startTool"]): DrawingP
 function toNonNegativeNumber(value: unknown, fallback: number): number {
   const normalized = toNumber(value, fallback);
   return normalized >= 0 ? normalized : fallback;
+}
+
+function toMinimumNumber(value: unknown, fallback: number, minimum: number): number {
+  return Math.max(toNumber(value, fallback), minimum);
 }
 
 function toBrushSize(value: unknown, fallback: DrawingProfile["brushSize"]): DrawingProfile["brushSize"] {
@@ -65,7 +69,11 @@ export async function loadProfile(profilePath?: string): Promise<DrawingProfile>
     homeDuration: toNumber(parsed.homeDuration, DEFAULT_PROFILE.homeDuration),
     buttonPressDuration: toNumber(parsed.buttonPressDuration, DEFAULT_PROFILE.buttonPressDuration),
     colorChangeDuration: toNumber(parsed.colorChangeDuration, DEFAULT_PROFILE.colorChangeDuration),
-    ackTimeoutMs: toNumber(parsed.ackTimeoutMs, DEFAULT_PROFILE.ackTimeoutMs),
+    ackTimeoutMs: toMinimumNumber(
+      parsed.ackTimeoutMs,
+      DEFAULT_PROFILE.ackTimeoutMs,
+      DEFAULT_ACK_TIMEOUT_MS,
+    ),
     commandRetryCount: toNumber(parsed.commandRetryCount, DEFAULT_PROFILE.commandRetryCount),
     drawButton: parsed.drawButton ?? DEFAULT_PROFILE.drawButton,
     colorMode:

--- a/apps/desktop/src/path/scanline.ts
+++ b/apps/desktop/src/path/scanline.ts
@@ -109,35 +109,6 @@ function buildSerpentineRows(pixels: Pixel[], fromBottom = false): Pixel[] {
   });
 }
 
-function rotatePixelsToNearestStart(
-  pixels: Pixel[],
-  current: { x: number; y: number },
-  grid: BrushGrid,
-): Pixel[] {
-  if (pixels.length <= 1) {
-    return pixels;
-  }
-
-  let nearestIndex = 0;
-  let nearestDistance = Number.POSITIVE_INFINITY;
-
-  pixels.forEach((pixel, index) => {
-    const target = toCanvasPosition(pixel, grid);
-    const distance = Math.abs(target.x - current.x) + Math.abs(target.y - current.y);
-
-    if (distance < nearestDistance) {
-      nearestDistance = distance;
-      nearestIndex = index;
-    }
-  });
-
-  if (nearestIndex === 0) {
-    return pixels;
-  }
-
-  return [...pixels.slice(nearestIndex), ...pixels.slice(0, nearestIndex)];
-}
-
 function chooseBestSerpentineOrder(
   pixels: Pixel[],
   current: { x: number; y: number },
@@ -147,26 +118,31 @@ function chooseBestSerpentineOrder(
     return pixels;
   }
 
-  const topDown = rotatePixelsToNearestStart(buildSerpentineRows(pixels, false), current, grid);
-  const bottomUp = rotatePixelsToNearestStart(buildSerpentineRows(pixels, true), current, grid);
+  const topDown = buildSerpentineRows(pixels, false);
+  const bottomUp = buildSerpentineRows(pixels, true);
+  const candidates = [
+    topDown,
+    [...topDown].reverse(),
+    bottomUp,
+    [...bottomUp].reverse(),
+  ];
+  let bestOrder = candidates[0] ?? pixels;
+  let bestDistance = Number.POSITIVE_INFINITY;
 
-  const topFirst = topDown[0];
-  const bottomFirst = bottomUp[0];
+  for (const candidate of candidates) {
+    if (candidate.length === 0) {
+      continue;
+    }
 
-  if (!topFirst) {
-    return bottomUp;
+    const distance = estimateTravelDistance(current, candidate, grid);
+
+    if (distance < bestDistance) {
+      bestDistance = distance;
+      bestOrder = candidate;
+    }
   }
 
-  if (!bottomFirst) {
-    return topDown;
-  }
-
-  const topStart = toCanvasPosition(topFirst, grid);
-  const bottomStart = toCanvasPosition(bottomFirst, grid);
-  const topDistance = Math.abs(topStart.x - current.x) + Math.abs(topStart.y - current.y);
-  const bottomDistance = Math.abs(bottomStart.x - current.x) + Math.abs(bottomStart.y - current.y);
-
-  return topDistance <= bottomDistance ? topDown : bottomUp;
+  return bestOrder;
 }
 
 function collectConnectedComponents(pixels: Pixel[]): Pixel[][] {
@@ -341,11 +317,7 @@ function getOrderedPixelsForColor(
   }
 
   const components = collectConnectedComponents(pixels);
-  const legacyPixels = rotatePixelsToNearestStart(
-    getLegacyScanlinePixels(pixels),
-    current,
-    grid,
-  );
+  const legacyPixels = chooseBestSerpentineOrder(pixels, current, grid);
 
   if (components.length <= 1) {
     return legacyPixels;
@@ -436,32 +408,33 @@ function findOptimalComponentOrder(
     pre: (typeof precomputed)[number],
     pos: { x: number; y: number },
   ): { pixels: Pixel[]; endPos: { x: number; y: number } } {
-    const td = rotatePixelsToNearestStart(pre.topDown, pos, grid);
-    const bu = rotatePixelsToNearestStart(pre.bottomUp, pos, grid);
+    const candidates = [
+      pre.topDown,
+      [...pre.topDown].reverse(),
+      pre.bottomUp,
+      [...pre.bottomUp].reverse(),
+    ];
+    let bestPixels: Pixel[] = [];
+    let bestDistance = Number.POSITIVE_INFINITY;
 
-    const tdStart = td[0];
-    const buStart = bu[0];
+    for (const candidate of candidates) {
+      if (candidate.length === 0) {
+        continue;
+      }
 
-    if (!tdStart) {
-      const last = bu[bu.length - 1];
-      return { pixels: bu, endPos: last ? toCanvasPosition(last, grid) : pos };
+      const distance = estimateTravelDistance(pos, candidate, grid);
+
+      if (distance < bestDistance) {
+        bestDistance = distance;
+        bestPixels = candidate;
+      }
     }
-    if (!buStart) {
-      const last = td[td.length - 1];
-      return { pixels: td, endPos: last ? toCanvasPosition(last, grid) : pos };
-    }
 
-    const tdPos = toCanvasPosition(tdStart, grid);
-    const buPos = toCanvasPosition(buStart, grid);
-    const tdDist = Math.abs(tdPos.x - pos.x) + Math.abs(tdPos.y - pos.y);
-    const buDist = Math.abs(buPos.x - pos.x) + Math.abs(buPos.y - pos.y);
-
-    if (tdDist <= buDist) {
-      const last = td[td.length - 1];
-      return { pixels: td, endPos: last ? toCanvasPosition(last, grid) : pos };
-    }
-    const last = bu[bu.length - 1];
-    return { pixels: bu, endPos: last ? toCanvasPosition(last, grid) : pos };
+    const last = bestPixels[bestPixels.length - 1];
+    return {
+      pixels: bestPixels,
+      endPos: last ? toCanvasPosition(last, grid) : pos,
+    };
   }
 
   let bestOrder: Pixel[] = [];

--- a/apps/desktop/src/web/server.ts
+++ b/apps/desktop/src/web/server.ts
@@ -9,6 +9,7 @@ import { fileURLToPath, pathToFileURL } from "node:url";
 import { generateDrawPlan } from "../app/generateDrawPlan.js";
 import { buildRecoveryExecutionPlan, deriveResumeProgress } from "../app/recovery.js";
 import { applyCliOptions, type CliOptions } from "../cli/args.js";
+import { DEFAULT_ACK_TIMEOUT_MS } from "../config/defaultProfile.js";
 import { loadProfile } from "../config/loadProfile.js";
 import { OFFICIAL_COLOR_GRID } from "../config/officialPalette.js";
 import {
@@ -78,6 +79,10 @@ const defaultAppDataRoot = path.join(os.homedir(), ".friend-maker");
 const MAX_FIRMWARE_FLASH_LOG_LINES = 800;
 const FIRMWARE_FLASH_TIMEOUT_MS = 15 * 60 * 1_000;
 const FIRMWARE_FLASH_CANCEL_GRACE_MS = 5_000;
+
+function normalizeAckTimeoutMs(value?: number): number {
+  return Math.max(value ?? DEFAULT_ACK_TIMEOUT_MS, DEFAULT_ACK_TIMEOUT_MS);
+}
 const serialSessionManager = new SerialSessionManager();
 
 export interface StartWebServerOptions {
@@ -1173,7 +1178,7 @@ async function executeCommands(body: {
   }
 
   const target = body.target === "serial" ? "serial" : "simulate";
-  const ackTimeoutMs = body.ackTimeoutMs ?? 5_000;
+  const ackTimeoutMs = normalizeAckTimeoutMs(body.ackTimeoutMs);
   const retries = body.retries ?? 1;
   const lines: string[] = [`INFO target=${target} commands=${body.commands.length}`];
 
@@ -1241,7 +1246,7 @@ async function runManagedExecution(
     errorAtCommand?: number;
   },
 ): Promise<void> {
-  const ackTimeoutMs = body.ackTimeoutMs ?? 5_000;
+  const ackTimeoutMs = normalizeAckTimeoutMs(body.ackTimeoutMs);
   const retries = body.retries ?? 1;
 
   appendManagedExecutionLine(
@@ -1647,7 +1652,7 @@ async function handleExecutionStart(
             profileSummary: normalizeRecoveryProfileSummary(body.profileSummary),
             serialOptions: {
               baudRate: body.baudRate ?? 115200,
-              ackTimeoutMs: body.ackTimeoutMs ?? 5_000,
+              ackTimeoutMs: normalizeAckTimeoutMs(body.ackTimeoutMs),
               retries: body.retries ?? 1,
             },
           })

--- a/apps/desktop/src/web/static/app.js
+++ b/apps/desktop/src/web/static/app.js
@@ -90,7 +90,7 @@ const state = {
     },
     profile: {
       baudRate: 115200,
-      ackTimeoutMs: 2000,
+      ackTimeoutMs: 5000,
       commandRetryCount: 1,
       inputDelay: 45,
       buttonPressDuration: 65,
@@ -998,7 +998,7 @@ function applyGeneratedStudioPayload(payload) {
     : [];
   state.studio.profile = {
     baudRate: payload.profile.baudRate ?? 115200,
-    ackTimeoutMs: payload.profile.ackTimeoutMs ?? 2000,
+    ackTimeoutMs: payload.profile.ackTimeoutMs ?? 5000,
     commandRetryCount: payload.profile.commandRetryCount ?? 1,
     inputDelay: payload.profile.inputDelay ?? state.sharedTiming.inputDelay,
     buttonPressDuration:

--- a/apps/desktop/test/three-layer-fix.test.ts
+++ b/apps/desktop/test/three-layer-fix.test.ts
@@ -150,6 +150,23 @@ function makeDrawingMask(
   };
 }
 
+function getSerializedLineVectors(commands: string[]): Array<{ dx: number; dy: number }> {
+  return commands.flatMap((command) => {
+    const match = /^L\s+(-?\d+)\s+(-?\d+)$/u.exec(command);
+
+    if (!match?.[1] || !match[2]) {
+      return [];
+    }
+
+    return [
+      {
+        dx: Number.parseInt(match[1], 10),
+        dy: Number.parseInt(match[2], 10),
+      },
+    ];
+  });
+}
+
 test("BrushGrid keeps pixelize, preview, bounds, and centers aligned", async () => {
   const brushSizes: BrushSize[] = [1, 3, 7, 13, 19, 27];
   const blankImage = await transparentPng(256, 256);
@@ -177,7 +194,7 @@ test("BrushGrid keeps pixelize, preview, bounds, and centers aligned", async () 
   }
 });
 
-test("transparent cells split horizontal L runs", () => {
+test("transparent cells still split into two short horizontal L runs from center start", () => {
   const profile = makeProfile({ canvasWidth: 5, canvasHeight: 1, brushSize: 1 });
   const pixelMap = makePixelMap(5, 1, [
     { x: 0, y: 0 },
@@ -186,12 +203,13 @@ test("transparent cells split horizontal L runs", () => {
     { x: 4, y: 0 },
   ]);
   const commands = serializeCommands(generateScanlineCommands(pixelMap, profile));
+  const lineCommands = getSerializedLineVectors(commands);
 
-  assert.equal(commands.filter((command) => command === "L 1 0").length, 2);
-  assert.equal(commands.includes("L 4 0"), false);
+  assert.equal(lineCommands.length, 2);
+  assert.equal(lineCommands.every((command) => Math.abs(command.dx) === 1 && command.dy === 0), true);
 });
 
-test("a 200 pixel horizontal line becomes one L run", () => {
+test("a 200 pixel horizontal line stays one L run from center start", () => {
   const profile = makeProfile({ canvasWidth: 200, canvasHeight: 1, brushSize: 1 });
   const pixelMap = makePixelMap(
     200,
@@ -199,9 +217,10 @@ test("a 200 pixel horizontal line becomes one L run", () => {
     Array.from({ length: 200 }, (_, x) => ({ x, y: 0 })),
   );
   const commands = serializeCommands(generateScanlineCommands(pixelMap, profile));
+  const lineCommands = getSerializedLineVectors(commands);
 
-  assert.equal(commands.filter((command) => command.startsWith("L ")).length, 1);
-  assert.equal(commands.includes("L 199 0"), true);
+  assert.equal(lineCommands.length, 1);
+  assert.deepEqual(lineCommands[0], { dx: -199, dy: 0 });
 });
 
 test("large brush centered blocks use grid origin instead of top-left bias", async () => {

--- a/apps/desktop/test/timing-config.test.ts
+++ b/apps/desktop/test/timing-config.test.ts
@@ -1,9 +1,14 @@
 import assert from "node:assert/strict";
+import os from "node:os";
+import path from "node:path";
+import { mkdtemp, rm, writeFile } from "node:fs/promises";
 import test from "node:test";
 
 import sharp from "sharp";
 
 import { buildRecoveryExecutionPlan } from "../src/app/recovery.js";
+import { DEFAULT_ACK_TIMEOUT_MS } from "../src/config/defaultProfile.js";
+import { loadProfile } from "../src/config/loadProfile.js";
 import { generateScanlinePlan } from "../src/path/scanline.js";
 import { serializeCommands } from "../src/protocol/serializer.js";
 import type { DrawingProfile, Pixel, PixelMap } from "../src/types.js";
@@ -109,6 +114,7 @@ test("/api/generate echoes timing overrides into commands and estimated runtime"
   assert.equal(defaultResponse.ok, true);
   const defaultPayload = (await defaultResponse.json()) as {
     commands: string[];
+    profile: { ackTimeoutMs: number };
     stats: { estimatedRuntimeMs: number };
   };
 
@@ -126,6 +132,7 @@ test("/api/generate echoes timing overrides into commands and estimated runtime"
   const overridePayload = (await overrideResponse.json()) as {
     commands: string[];
     profile: {
+      ackTimeoutMs: number;
       inputDelay: number;
       buttonPressDuration: number;
       homeDuration: number;
@@ -134,7 +141,9 @@ test("/api/generate echoes timing overrides into commands and estimated runtime"
   };
 
   assert.equal(defaultPayload.commands[0], "CFG INPUT 65 45 1800");
+  assert.equal(defaultPayload.profile.ackTimeoutMs, DEFAULT_ACK_TIMEOUT_MS);
   assert.equal(overridePayload.commands[0], "CFG INPUT 40 30 1800");
+  assert.equal(overridePayload.profile.ackTimeoutMs, DEFAULT_ACK_TIMEOUT_MS);
   assert.equal(overridePayload.profile.inputDelay, 30);
   assert.equal(overridePayload.profile.buttonPressDuration, 40);
   assert.equal(overridePayload.profile.homeDuration, 1800);
@@ -142,4 +151,26 @@ test("/api/generate echoes timing overrides into commands and estimated runtime"
     overridePayload.stats.estimatedRuntimeMs < defaultPayload.stats.estimatedRuntimeMs,
     "expected faster timing overrides to reduce estimated runtime",
   );
+});
+
+test("loadProfile clamps legacy ack timeout values to the supported minimum", async (t) => {
+  const tempDir = await mkdtemp(path.join(os.tmpdir(), "friendmaker-profile-"));
+  t.after(async () => {
+    await rm(tempDir, { recursive: true, force: true });
+  });
+
+  const profilePath = path.join(tempDir, "legacy-profile.json");
+  await writeFile(
+    profilePath,
+    JSON.stringify({
+      ...makeProfile(),
+      profileName: "legacy-timeout-profile",
+      ackTimeoutMs: 2_000,
+    }),
+    "utf8",
+  );
+
+  const profile = await loadProfile(profilePath);
+
+  assert.equal(profile.ackTimeoutMs, DEFAULT_ACK_TIMEOUT_MS);
 });

--- a/profiles/switch-mono-128.json
+++ b/profiles/switch-mono-128.json
@@ -9,7 +9,7 @@
   "homeDuration": 1800,
   "buttonPressDuration": 100,
   "colorChangeDuration": 450,
-  "ackTimeoutMs": 2000,
+  "ackTimeoutMs": 5000,
   "commandRetryCount": 1,
   "drawButton": "A",
   "colorMode": "mono",

--- a/profiles/switch-mono-256.json
+++ b/profiles/switch-mono-256.json
@@ -9,7 +9,7 @@
   "homeDuration": 1800,
   "buttonPressDuration": 100,
   "colorChangeDuration": 450,
-  "ackTimeoutMs": 2000,
+  "ackTimeoutMs": 5000,
   "commandRetryCount": 1,
   "drawButton": "A",
   "colorMode": "mono",

--- a/profiles/switch-mono-32.json
+++ b/profiles/switch-mono-32.json
@@ -9,7 +9,7 @@
   "homeDuration": 1800,
   "buttonPressDuration": 100,
   "colorChangeDuration": 450,
-  "ackTimeoutMs": 2000,
+  "ackTimeoutMs": 5000,
   "commandRetryCount": 1,
   "drawButton": "A",
   "colorMode": "mono",

--- a/profiles/switch-palette-32.json
+++ b/profiles/switch-palette-32.json
@@ -9,7 +9,7 @@
   "homeDuration": 1800,
   "buttonPressDuration": 100,
   "colorChangeDuration": 650,
-  "ackTimeoutMs": 2000,
+  "ackTimeoutMs": 5000,
   "commandRetryCount": 1,
   "drawButton": "A",
   "colorMode": "palette",


### PR DESCRIPTION

### Summary
- Raise the default/minimum `ackTimeoutMs` to `5000ms` and add consistent clamping for legacy profiles and runtime inputs.
- Update bundled profiles and frontend defaults to reduce unstable executions caused by overly short ACK timeouts.
- Fix scanline path selection so long horizontal runs are not incorrectly split in center-start scenarios.
- Add and update related test coverage.

### Validation
- `npm run check`
- `npm run test:desktop`
