### PR TITLE
Fix Switch pairing status and serial startup

### DIFF
--- a/apps/desktop/src/serial/sender.ts
+++ b/apps/desktop/src/serial/sender.ts
@@ -18,6 +18,9 @@ import type { ProgressUpdate, SenderControls } from "../types.js";
 const ACK_LINE_PREFIXES = ["OK ", "ERR "] as const;
 const DEVICE_LINE_PREFIXES = ["INFO ", "WARN ", "BOOT ", "rst:"] as const;
 export const DEFAULT_SERIAL_SESSION_IDLE_TIMEOUT_MS = 15 * 60 * 1_000;
+const SERIAL_OPEN_STABILIZE_DELAY_MS = 500;
+const SERIAL_OPEN_BOOT_DETECT_MS = 1_000;
+const SERIAL_OPEN_BOOT_TIMEOUT_MS = 12_000;
 const CONTROLLER_SEND_REPORT_FAILURE_THRESHOLD = 10;
 const COLOR_PALETTE_SLOT_COUNT = 9;
 const COLOR_PALETTE_RESET_TO_BOTTOM_STEPS = 18;
@@ -381,7 +384,7 @@ export function getAckTimeoutForCommand(
     return Math.max(baseTimeoutMs, 1_000 + timing.homeMs * 2 + timing.inputDelayMs);
   }
 
-  if (trimmed === "BT RESET") {
+  if (trimmed === "BT RESET" || trimmed === "BT RESET LAST-PEER") {
     return Math.max(baseTimeoutMs, 20_000);
   }
 
@@ -495,14 +498,17 @@ function openPort(port: SerialPort): Promise<void> {
   });
 }
 
-function flushPort(port: SerialPort): Promise<void> {
+function setPortSignals(
+  port: SerialPort,
+  options: { dtr?: boolean; rts?: boolean; brk?: boolean },
+): Promise<void> {
   return new Promise((resolve, reject) => {
     if (!port.isOpen) {
       resolve();
       return;
     }
 
-    port.flush((error) => {
+    port.set(options, (error) => {
       if (error) {
         reject(error);
         return;
@@ -510,6 +516,74 @@ function flushPort(port: SerialPort): Promise<void> {
 
       resolve();
     });
+  });
+}
+
+function sleep(ms: number): Promise<void> {
+  return new Promise((resolve) => setTimeout(resolve, ms));
+}
+
+function waitForDeviceBoot(
+  parser: ReadlineParser,
+  port: SerialPort,
+  options?: {
+    onDeviceLine?: (line: string) => void;
+  },
+): Promise<"booted" | "idle" | "timed_out"> {
+  return new Promise((resolve) => {
+    let finished = false;
+    let sawReset = false;
+
+    const finish = (result: "booted" | "idle" | "timed_out") => {
+      if (finished) {
+        return;
+      }
+
+      finished = true;
+      clearTimeout(idleTimer);
+      clearTimeout(timeoutTimer);
+      parser.off("data", onData);
+      port.off("close", onClose);
+      port.off("error", onError);
+      resolve(result);
+    };
+
+    const onData = (rawLine: string | Buffer) => {
+      const line = sanitizeDeviceLine(rawLine);
+
+      if (!line) {
+        return;
+      }
+
+      options?.onDeviceLine?.(line);
+
+      if (line.startsWith("rst:")) {
+        sawReset = true;
+        return;
+      }
+
+      if (line.startsWith("BOOT ")) {
+        sawReset = true;
+        finish("booted");
+      }
+    };
+
+    const onClose = () => finish("timed_out");
+    const onError = () => finish("timed_out");
+
+    const idleTimer = setTimeout(() => {
+      if (!sawReset) {
+        finish("idle");
+      }
+    }, SERIAL_OPEN_BOOT_DETECT_MS);
+
+    const timeoutTimer = setTimeout(() => {
+      finish(sawReset ? "timed_out" : "idle");
+    }, SERIAL_OPEN_BOOT_TIMEOUT_MS);
+
+    parser.on("data", onData);
+    port.on("close", onClose);
+    port.on("error", onError);
   });
 }
 
@@ -585,18 +659,47 @@ export class SerialCommandSession {
         throw new Error("Serial session is not open.");
       }
 
+      this.parser = port.pipe(new ReadlineParser({ delimiter: "\n" }));
+
       try {
-        await flushPort(port);
+        await setPortSignals(port, { dtr: false, rts: false, brk: false });
       } catch (error) {
         const message = error instanceof Error ? error.message : String(error);
-        onDeviceLine?.(`WARN serial_flush_failed reason=${message}`);
+        onDeviceLine?.(`WARN serial_signal_init_failed reason=${message}`);
+      }
+
+      onDeviceLine?.(
+        `INFO serial_session=stabilizing port=${this.portPath} wait_ms=${SERIAL_OPEN_STABILIZE_DELAY_MS}`,
+      );
+      await sleep(SERIAL_OPEN_STABILIZE_DELAY_MS);
+
+      if (this.port !== port || !port.isOpen) {
+        throw new Error("Serial session is not open.");
+      }
+
+      if (this.parser) {
+        onDeviceLine?.(
+          `INFO serial_session=waiting_boot port=${this.portPath} timeout_ms=${SERIAL_OPEN_BOOT_TIMEOUT_MS}`,
+        );
+        const bootResult = await waitForDeviceBoot(this.parser, port, {
+          ...(onDeviceLine ? { onDeviceLine } : {}),
+        });
+
+        if (bootResult === "booted") {
+          onDeviceLine?.(`INFO serial_session=boot_ready port=${this.portPath}`);
+        } else if (bootResult === "timed_out") {
+          onDeviceLine?.(
+            `WARN serial_session=boot_wait_timeout port=${this.portPath} timeout_ms=${SERIAL_OPEN_BOOT_TIMEOUT_MS}`,
+          );
+        } else {
+          onDeviceLine?.(`INFO serial_session=boot_wait_skipped port=${this.portPath}`);
+        }
       }
 
       if (this.port !== port || !port.isOpen) {
         throw new Error("Serial session is not open.");
       }
 
-      this.parser = port.pipe(new ReadlineParser({ delimiter: "\n" }));
       this.lastUsedAtValue = Date.now();
       onDeviceLine?.(`INFO serial_session=open port=${this.portPath} baud=${this.baudRate}`);
     })();

--- a/apps/desktop/src/web/server.ts
+++ b/apps/desktop/src/web/server.ts
@@ -80,8 +80,14 @@ const MAX_FIRMWARE_FLASH_LOG_LINES = 800;
 const FIRMWARE_FLASH_TIMEOUT_MS = 15 * 60 * 1_000;
 const FIRMWARE_FLASH_CANCEL_GRACE_MS = 5_000;
 
-function normalizeAckTimeoutMs(value?: number): number {
-  return Math.max(value ?? DEFAULT_ACK_TIMEOUT_MS, DEFAULT_ACK_TIMEOUT_MS);
+export function resolveAckTimeoutMs(
+  value?: number,
+  options: { enforceMinimum?: boolean } = {},
+): number {
+  const normalized = value ?? DEFAULT_ACK_TIMEOUT_MS;
+  return options.enforceMinimum === false
+    ? normalized
+    : Math.max(normalized, DEFAULT_ACK_TIMEOUT_MS);
 }
 const serialSessionManager = new SerialSessionManager();
 
@@ -1163,6 +1169,7 @@ async function executeCommands(body: {
   portPath?: string;
   baudRate?: number;
   ackTimeoutMs?: number;
+  enforceMinimumAckTimeout?: boolean;
   retries?: number;
   ackDelayMs?: number;
   errorAtCommand?: number;
@@ -1178,9 +1185,16 @@ async function executeCommands(body: {
   }
 
   const target = body.target === "serial" ? "serial" : "simulate";
-  const ackTimeoutMs = normalizeAckTimeoutMs(body.ackTimeoutMs);
+  const enforceMinimumAckTimeout = body.enforceMinimumAckTimeout !== false;
+  const ackTimeoutMs = resolveAckTimeoutMs(body.ackTimeoutMs, {
+    enforceMinimum: enforceMinimumAckTimeout,
+  });
   const retries = body.retries ?? 1;
-  const lines: string[] = [`INFO target=${target} commands=${body.commands.length}`];
+  const lines: string[] = [
+    `INFO target=${target} commands=${body.commands.length}`,
+    `INFO ack_timeout_ms=${ackTimeoutMs}`,
+    `INFO ack_timeout_floor_enforced=${enforceMinimumAckTimeout ? "true" : "false"}`,
+  ];
 
   try {
     if (target === "serial") {
@@ -1246,7 +1260,7 @@ async function runManagedExecution(
     errorAtCommand?: number;
   },
 ): Promise<void> {
-  const ackTimeoutMs = normalizeAckTimeoutMs(body.ackTimeoutMs);
+  const ackTimeoutMs = resolveAckTimeoutMs(body.ackTimeoutMs);
   const retries = body.retries ?? 1;
 
   appendManagedExecutionLine(
@@ -1588,6 +1602,7 @@ async function handleExecute(request: IncomingMessage, response: ServerResponse)
     portPath?: string;
     baudRate?: number;
     ackTimeoutMs?: number;
+    enforceMinimumAckTimeout?: boolean;
     retries?: number;
     ackDelayMs?: number;
     errorAtCommand?: number;
@@ -1652,7 +1667,7 @@ async function handleExecutionStart(
             profileSummary: normalizeRecoveryProfileSummary(body.profileSummary),
             serialOptions: {
               baudRate: body.baudRate ?? 115200,
-              ackTimeoutMs: normalizeAckTimeoutMs(body.ackTimeoutMs),
+              ackTimeoutMs: resolveAckTimeoutMs(body.ackTimeoutMs),
               retries: body.retries ?? 1,
             },
           })

--- a/apps/desktop/src/web/static/app.js
+++ b/apps/desktop/src/web/static/app.js
@@ -369,6 +369,7 @@ let studioPreviewBoundsRequestSerial = 0;
 const studioTemplateOverlayCache = new Map();
 const CONTROLLER_STATUS_POLL_INTERVAL_MS = 1_000;
 const CONTROLLER_STATUS_POLL_WINDOW_MS = 45_000;
+const CONTROLLER_COMPAT_ACK_TIMEOUT_MS = 2_000;
 
 const COLOR_COUNT_OPTIONS_BY_MODE = {
   mono: [2],
@@ -2554,7 +2555,8 @@ async function requestControllerStatus({ logErrors = false } = {}) {
         commands: ["I"],
         portPath: state.selectedPortPath,
         baudRate: state.studio.profile.baudRate,
-        ackTimeoutMs: state.studio.profile.ackTimeoutMs,
+        ackTimeoutMs: CONTROLLER_COMPAT_ACK_TIMEOUT_MS,
+        enforceMinimumAckTimeout: false,
         retries: state.studio.profile.commandRetryCount,
         ackDelayMs: 0,
       }),
@@ -3228,6 +3230,7 @@ async function runExecution({
   portPath,
   baudRate,
   ackTimeoutMs,
+  enforceMinimumAckTimeout = true,
   retries,
   setBusy,
   logTarget,
@@ -3245,6 +3248,7 @@ async function runExecution({
         portPath: target === "serial" ? portPath : undefined,
         baudRate,
         ackTimeoutMs,
+        enforceMinimumAckTimeout,
         retries,
         ackDelayMs: 0,
       }),
@@ -3278,6 +3282,8 @@ async function runTimedSerialCommands({
   logTarget,
   setBusy,
   successLabel,
+  ackTimeoutMs = state.studio.profile.ackTimeoutMs,
+  enforceMinimumAckTimeout = true,
 }) {
   if (!state.selectedPortPath) {
     appendLog(logTarget, "请先选择一个串口设备。");
@@ -3293,7 +3299,8 @@ async function runTimedSerialCommands({
     target: "serial",
     portPath: state.selectedPortPath,
     baudRate: state.studio.profile.baudRate,
-    ackTimeoutMs: state.studio.profile.ackTimeoutMs,
+    ackTimeoutMs,
+    enforceMinimumAckTimeout,
     retries: state.studio.profile.commandRetryCount,
     setBusy,
     logTarget,
@@ -3318,6 +3325,8 @@ async function runControllerCommands(commands, label) {
     logTarget: els.controllerLogOutput,
     setBusy: setControllerBusy,
     successLabel: label,
+    ackTimeoutMs: CONTROLLER_COMPAT_ACK_TIMEOUT_MS,
+    enforceMinimumAckTimeout: false,
   });
   const payload = result?.payload ?? null;
 

--- a/apps/desktop/src/web/static/app.js
+++ b/apps/desktop/src/web/static/app.js
@@ -1,5 +1,6 @@
 import {
   deriveControllerStatus,
+  shouldAutoReconnectLastPeer,
   shouldReuseExistingControllerConnection,
 } from "./controllerStatus.js";
 
@@ -158,6 +159,8 @@ const state = {
       paired: "未知",
       ready: "未知",
       peer: "-",
+      localMac: "-",
+      reply02Mac: "-",
       initStep: "-",
       initError: "-",
       discoverableValue: null,
@@ -167,6 +170,9 @@ const state = {
       readyValue: null,
       rawReadyValue: null,
       readyInferredValue: false,
+      reportChannelOpenValue: null,
+      identityMismatchValue: false,
+      switchAcceptedValue: false,
       unstableValue: false,
       reconnectRecommendedValue: false,
       sendReportFailureCount: 0,
@@ -1810,7 +1816,12 @@ els.controllerResetButton.addEventListener("click", async () => {
     detail: "正在重启蓝牙协议栈并读取最新状态，请稍等片刻。",
   });
 
-  const payload = await runControllerCommands(["BT RESET", "I"], "重置手柄蓝牙");
+  const payload = await runControllerCommands(
+    shouldAutoReconnectLastPeer(state.controller.status)
+      ? ["BT RESET LAST-PEER", "I"]
+      : ["BT RESET", "I"],
+    "重置手柄蓝牙",
+  );
 
   if (payload) {
     startControllerStatusPolling();
@@ -2433,6 +2444,9 @@ function setControllerPendingStatus({ title, detail }) {
     readyValue: false,
     rawReadyValue: null,
     readyInferredValue: false,
+    reportChannelOpenValue: null,
+    identityMismatchValue: false,
+    switchAcceptedValue: false,
     unstableValue: false,
     reconnectRecommendedValue: false,
     sendReportFailureCount: 0,
@@ -2440,6 +2454,8 @@ function setControllerPendingStatus({ title, detail }) {
     lastSendReportReason: null,
     lastAclDisconnectReason: null,
     lastDropReason: "-",
+    localMac: "-",
+    reply02Mac: "-",
     initStep: "-",
     initError: "-",
   });
@@ -2469,6 +2485,7 @@ function setControllerRecoveryFailedStatus(detail) {
 
 function isControllerConnectionStillInProgress(status = state.controller.status) {
   return (
+    status?.switchAcceptedValue !== true &&
     status?.readyValue !== true &&
     status?.tone !== "error" &&
     (status?.connectedValue === true ||
@@ -2479,6 +2496,8 @@ function isControllerConnectionStillInProgress(status = state.controller.status)
 
 async function handleControllerStatusPollTimeout() {
   stopControllerStatusPolling();
+  const shouldReconnectLastPeer = shouldAutoReconnectLastPeer(state.controller.status);
+  const resetCommands = shouldReconnectLastPeer ? ["BT RESET LAST-PEER", "I"] : ["BT RESET", "I"];
 
   if (
     isControllerConnectionStillInProgress() &&
@@ -2494,10 +2513,7 @@ async function handleControllerStatusPollTimeout() {
       detail: "开发板长时间停留在广播或握手状态，正在重置蓝牙并重新进入可发现状态。",
     });
 
-    const payload = await runControllerCommands(
-      ["BT RESET LAST-PEER", "I"],
-      "自动恢复手柄连接",
-    );
+    const payload = await runControllerCommands(resetCommands, "自动恢复手柄连接");
 
     if (payload) {
       startControllerStatusPolling();
@@ -2611,7 +2627,9 @@ async function pollControllerStatus() {
       });
 
       const payload = await runControllerCommands(
-        ["BT RESET LAST-PEER", "I"],
+        shouldAutoReconnectLastPeer(state.controller.status)
+          ? ["BT RESET LAST-PEER", "I"]
+          : ["BT RESET", "I"],
         "自动恢复手柄连接",
       );
 

--- a/apps/desktop/src/web/static/controllerStatus.d.ts
+++ b/apps/desktop/src/web/static/controllerStatus.d.ts
@@ -17,6 +17,9 @@ export interface DerivedControllerStatus {
   readyValue: boolean | null;
   rawReadyValue: boolean | null;
   readyInferredValue: boolean;
+  reportChannelOpenValue: boolean | null;
+  identityMismatchValue: boolean;
+  switchAcceptedValue: boolean;
   unstableValue: boolean;
   reconnectRecommendedValue: boolean;
   sendReportFailureCount: number;
@@ -25,6 +28,8 @@ export interface DerivedControllerStatus {
   lastAclDisconnectReason: number | null;
   lastDropReason: string;
   peer: string;
+  localMac: string;
+  reply02Mac: string;
   initStep: string;
   initError: string;
 }
@@ -45,6 +50,15 @@ export function shouldReuseExistingControllerConnection(status: {
   discoverableValue?: boolean | null;
   reconnectRecommendedValue?: boolean | null;
   unstableValue?: boolean | null;
+  initStep?: string | null;
+} | null | undefined): boolean;
+export function shouldAutoReconnectLastPeer(status: {
+  readyValue?: boolean | null;
+  connectedValue?: boolean | null;
+  authValue?: boolean | null;
+  pairedValue?: boolean | null;
+  initStep?: string | null;
+  peer?: string | null;
 } | null | undefined): boolean;
 export function deriveControllerStatus(
   lines: Array<string | null | undefined>,

--- a/apps/desktop/src/web/static/controllerStatus.js
+++ b/apps/desktop/src/web/static/controllerStatus.js
@@ -47,6 +47,16 @@ function numberFromInfo(value) {
   return Number.isFinite(parsed) ? parsed : null;
 }
 
+function normalizeBluetoothMac(value) {
+  const normalized = String(value ?? "").trim().toUpperCase();
+
+  if (!normalized || normalized === "-") {
+    return null;
+  }
+
+  return /^[0-9A-F]{2}(?::[0-9A-F]{2}){5}$/u.test(normalized) ? normalized : null;
+}
+
 export function normalizeControllerDeviceLines(lines) {
   return (lines ?? []).flatMap((line) => splitEmbeddedDeviceLine(line));
 }
@@ -103,12 +113,30 @@ export function shouldReuseExistingControllerConnection(status) {
   return (
     status?.readyValue === true ||
     status?.connectedValue === true ||
-    status?.authValue === true
+    status?.authValue === true ||
+    status?.initStep === "hid-connecting"
+  );
+}
+
+export function shouldAutoReconnectLastPeer(status) {
+  const rememberedPeer =
+    typeof status?.peer === "string" &&
+    status.peer !== "-" &&
+    status.peer.includes(":");
+
+  return (
+    status?.readyValue === true ||
+    status?.connectedValue === true ||
+    status?.authValue === true ||
+    status?.pairedValue === true ||
+    status?.initStep === "hid-connecting" ||
+    rememberedPeer
   );
 }
 
 export function deriveControllerStatus(lines) {
-  const info = readInfoLineMap(lines);
+  const normalizedLines = normalizeControllerDeviceLines(lines);
+  const info = readInfoLineMap(normalizedLines);
 
   if (!info.transport && !info.bt_mode && !info.bt_profile) {
     return null;
@@ -119,23 +147,55 @@ export function deriveControllerStatus(lines) {
   const connected = boolFromInfo(info.bt_connected);
   const paired = boolFromInfo(info.bt_paired);
   const rawReady = boolFromInfo(info.bt_ready_for_reports);
+  const reportChannelOpen = boolFromInfo(info.bt_report_channel_open);
   const sendReportFailureCount = numberFromInfo(info.bt_send_report_failures) ?? 0;
   const lastSendReportStatus = numberFromInfo(info.bt_last_send_report_status);
   const lastSendReportReason = numberFromInfo(info.bt_last_send_report_reason);
   const lastAclDisconnectReason = numberFromInfo(info.bt_last_acl_disconnect_reason);
+  const normalizedLocalMac = normalizeBluetoothMac(info.bt_local_mac);
+  const normalizedReply02Mac = normalizeBluetoothMac(info.bt_reply02_mac);
+  const localMac = normalizedLocalMac ?? "-";
+  const reply02Mac = normalizedReply02Mac ?? "-";
+  const identityMismatch =
+    normalizedLocalMac !== null &&
+    normalizedReply02Mac !== null &&
+    normalizedLocalMac !== normalizedReply02Mac;
+  const sawSuccessfulAuthEvent = normalizedLines.some((line) =>
+    /^INFO bt auth status=0(?:\s|$)/u.test(line),
+  );
+  const sawConnectedOpenEvent = normalizedLines.some((line) =>
+    /^INFO bt hid event=open status=0 conn=0(?:\s|$)/u.test(line),
+  );
+  const sawLegacyConnectingOpen = normalizedLines.some((line) =>
+    /^INFO bt hid event=open status=0 conn=1(?:\s|$)/u.test(line),
+  );
+  const inferredAuthComplete = authComplete === true || sawSuccessfulAuthEvent;
+  const inferredConnected =
+    connected === true ||
+    sawConnectedOpenEvent ||
+    info.bt_init_step === "hid-connecting";
   const congestedSendReport =
     lastSendReportStatus !== null &&
     lastSendReportStatus > 0 &&
     lastSendReportReason === 8;
   const unstableInferredReady =
     rawReady !== true &&
-    connected === true &&
+    inferredConnected === true &&
     paired === true &&
     congestedSendReport &&
     sendReportFailureCount >= 10;
-  const readyInferredFromPairing = rawReady !== true && connected === true && paired === true && !unstableInferredReady;
+  const readyInferredFromPairing =
+    rawReady !== true &&
+    inferredConnected === true &&
+    paired === true &&
+    !unstableInferredReady;
   const ready = rawReady === true || readyInferredFromPairing;
   const initError = info.bt_init_error ?? "-";
+  const switchAcceptedConnection =
+    ready !== true &&
+    paired !== true &&
+    info.bt_init_step === "hid-connecting" &&
+    (inferredConnected === true || sawLegacyConnectingOpen || sawConnectedOpenEvent);
 
   let tone = "idle";
   let pill = "待连接";
@@ -149,18 +209,55 @@ export function deriveControllerStatus(lines) {
     detail = readyInferredFromPairing
       ? "开发板已经完成 HID 连接和配对；固件报告通道字段可能滞后，但当前状态已经可以发送按钮和摇杆报告。"
       : "开发板已经完成连接并可发送按钮和摇杆报告，可以继续做手柄测试。";
+    if (identityMismatch) {
+      tone = "warning";
+      pill = "身份异常";
+      title = "手柄身份不一致";
+      detail =
+        `开发板已经能发送输入，但它当前蓝牙地址是 ${localMac}，对外回复的 device-info 地址却是 ${reply02Mac}。这种身份不一致会让首配、回连或跨设备识别变得不稳定，建议更新固件后重试。`;
+    }
   } else if (unstableInferredReady) {
     tone = "warning";
     pill = "不稳定";
     title = "连接容易断开";
     detail =
       `开发板已经连上 Switch，但 HID 报告通道仍在拥塞（最近一次 send-report status=${lastSendReportStatus ?? "-"} reason=${lastSendReportReason ?? "-"}，累计失败 ${sendReportFailureCount} 次），现在继续测试或开画都容易断联。建议先重置蓝牙后重新连接。`;
-  } else if (connected === true) {
+  } else if (identityMismatch) {
+    tone = "warning";
+    pill = "身份异常";
+    title = "控制器身份不一致";
+    detail =
+      `当前蓝牙地址是 ${localMac}，但 device-info 回复地址是 ${reply02Mac}。这会让 Switch 在发现、配对或回连阶段更容易把这块板子当成不稳定手柄。建议重新刷固件后再试。`;
+  } else if (switchAcceptedConnection) {
+    tone = "success";
+    pill = "已连接";
+    title = "Switch 已接受连接";
+    detail =
+      "Switch 侧已经弹出并接受了连接成功提示，开发板正在完成最后的 HID 握手和输入就绪切换。当前页面会显示连接成功，但仍需等待状态进入“可发送”后再开始正式绘制。";
+  } else if (
+    info.bt_init_step === "hid-open-failed" &&
+    inferredConnected !== true &&
+    sawLegacyConnectingOpen
+  ) {
+    tone = "warning";
+    pill = "待刷固件";
+    title = "开发板固件需要更新";
+    detail =
+      "当前开发板已经进入 HID connecting，但板子上的旧固件仍把这个阶段记成 hid-open-failed。请先重新刷入当前分支的最新 ESP32 固件，再继续测试连接。";
+  } else if (info.bt_init_step === "hid-connecting") {
+    tone = "running";
+    pill = "握手中";
+    title = "正在回连上次主机";
+    detail = "开发板已经开始尝试回连上次配对的 Switch，正在等待 HID 连接真正建立。";
+  } else if (inferredConnected === true) {
     tone = "running";
     pill = "已连接";
     title = "连接已建立";
-    detail = "HID 连接已经建立，正在等待配对完成或报告通道完全就绪。";
-  } else if (authComplete === true) {
+    detail =
+      reportChannelOpen === true
+        ? "HID 连接和报告通道已经打开，正在等待 Switch 完成控制器子命令握手。"
+        : "HID 连接已经建立，正在等待报告通道完全就绪。";
+  } else if (inferredAuthComplete === true) {
     tone = "running";
     pill = "已认证";
     title = "认证已通过";
@@ -185,20 +282,25 @@ export function deriveControllerStatus(lines) {
     transport: info.transport ?? "-",
     profile: info.bt_profile ?? info.bt_mode ?? "-",
     discoverable: boolLabel(discoverable, ["可发现", "未发现"]),
-    auth: boolLabel(authComplete, ["已通过", "未通过"]),
-    connected: boolLabel(connected, ["已连接", "未连接"]),
+    auth: boolLabel(inferredAuthComplete, ["已通过", "未通过"]),
+    connected: boolLabel(inferredConnected, ["已连接", "未连接"]),
     paired: boolLabel(paired, ["已配对", "未配对"]),
     ready: boolLabel(ready, ["可发送", "未就绪"]),
     discoverableValue: discoverable,
-    authValue: authComplete,
-    connectedValue: connected,
+    authValue: inferredAuthComplete,
+    connectedValue: inferredConnected,
     pairedValue: paired,
     readyValue: ready,
+    reportChannelOpenValue: reportChannelOpen,
     peer: info.bt_last_peer ?? "-",
+    localMac,
+    reply02Mac,
     initStep: info.bt_init_step ?? "-",
     initError,
     rawReadyValue: rawReady,
     readyInferredValue: readyInferredFromPairing,
+    identityMismatchValue: identityMismatch,
+    switchAcceptedValue: switchAcceptedConnection,
     unstableValue: unstableInferredReady,
     reconnectRecommendedValue: unstableInferredReady,
     sendReportFailureCount,

--- a/apps/desktop/test/controller-status.test.ts
+++ b/apps/desktop/test/controller-status.test.ts
@@ -6,6 +6,7 @@ import {
   deriveControllerStatus,
   normalizeControllerDeviceLines,
   readInfoLineMap,
+  shouldAutoReconnectLastPeer,
   shouldReuseExistingControllerConnection,
 } from "../src/web/static/controllerStatus.js";
 
@@ -30,6 +31,7 @@ test("readInfoLineMap keeps info fields clean when warn lines are glued on", () 
     "INFO bt_init_step=discoverable",
     "INFO bt_init_error=ESP_OKWARN bt hid event=send-report status=1 reason=8 report=48",
     "INFO bt_last_peer=11:22:33:44:55:66INFO bt_last_send_report_status=1",
+    "INFO bt_local_mac=D4:F0:57:AA:BB:CCINFO bt_reply02_mac=D4:F0:57:AA:BB:CC",
   ]);
 
   assert.equal(info.transport, "classic-bt-uartswitchcon");
@@ -38,6 +40,8 @@ test("readInfoLineMap keeps info fields clean when warn lines are glued on", () 
   assert.equal(info.bt_init_error, "ESP_OK");
   assert.equal(info.bt_last_peer, "11:22:33:44:55:66");
   assert.equal(info.bt_last_send_report_status, "1");
+  assert.equal(info.bt_local_mac, "D4:F0:57:AA:BB:CC");
+  assert.equal(info.bt_reply02_mac, "D4:F0:57:AA:BB:CC");
 });
 
 test("deriveControllerStatus prefers connected-ready progress over stale init error display", () => {
@@ -91,6 +95,104 @@ test("deriveControllerStatus marks congested inferred-ready links as unstable", 
   assert.equal(status?.lastAclDisconnectReason, 19);
 });
 
+test("deriveControllerStatus flags device identity mismatches before the controller is ready", () => {
+  const status = deriveControllerStatus([
+    "INFO transport=classic-bt-uartswitchcon",
+    "INFO bt_profile=uartswitchcon-pro-controller",
+    "INFO bt_discoverable=false",
+    "INFO bt_auth_complete=true",
+    "INFO bt_connected=false",
+    "INFO bt_paired=false",
+    "INFO bt_ready_for_reports=false",
+    "INFO bt_report_channel_open=false",
+    "INFO bt_local_mac=D4:F0:57:AA:BB:CC",
+    "INFO bt_reply02_mac=D4:F0:57:11:22:33",
+    "INFO bt_init_step=auth-complete",
+    "INFO bt_init_error=ESP_OK",
+  ]);
+
+  assert.ok(status);
+  assert.equal(status?.tone, "warning");
+  assert.equal(status?.pill, "身份异常");
+  assert.equal(status?.title, "控制器身份不一致");
+  assert.equal(status?.localMac, "D4:F0:57:AA:BB:CC");
+  assert.equal(status?.reply02Mac, "D4:F0:57:11:22:33");
+  assert.equal(status?.identityMismatchValue, true);
+  assert.equal(status?.reportChannelOpenValue, false);
+});
+
+test("deriveControllerStatus ignores incomplete local MAC reads before declaring an identity mismatch", () => {
+  const status = deriveControllerStatus([
+    "INFO transport=classic-bt-uartswitchcon",
+    "INFO bt_profile=uartswitchcon-pro-controller",
+    "INFO bt_discoverable=false",
+    "INFO bt_auth_complete=true",
+    "INFO bt_connected=true",
+    "INFO bt_paired=true",
+    "INFO bt_ready_for_reports=true",
+    "INFO bt_report_channel_open=true",
+    "INFO bt_local_mac=",
+    "INFO bt_reply02_mac=D4:F0:57:52:8A:D4",
+    "INFO bt_init_step=hid-open",
+    "INFO bt_init_error=ESP_OK",
+  ]);
+
+  assert.ok(status);
+  assert.equal(status?.tone, "success");
+  assert.equal(status?.pill, "已就绪");
+  assert.equal(status?.title, "手柄已连接");
+  assert.equal(status?.localMac, "-");
+  assert.equal(status?.reply02Mac, "D4:F0:57:52:8A:D4");
+  assert.equal(status?.identityMismatchValue, false);
+});
+
+test("deriveControllerStatus shows Switch-accepted reconnects as connected before reports are ready", () => {
+  const status = deriveControllerStatus([
+    "INFO transport=classic-bt-uartswitchcon",
+    "INFO bt_profile=uartswitchcon-pro-controller",
+    "INFO bt auth status=0 device=\"Nintendo Switch\"",
+    "INFO bt hid event=open status=0 conn=1 peer=unknown",
+    "INFO bt_discoverable=true",
+    "INFO bt_connected=false",
+    "INFO bt_auth_complete=false",
+    "INFO bt_paired=false",
+    "INFO bt_ready_for_reports=false",
+    "INFO bt_report_channel_open=false",
+    "INFO bt_init_step=hid-connecting",
+    "INFO bt_init_error=ESP_OK",
+  ]);
+
+  assert.ok(status);
+  assert.equal(status?.tone, "success");
+  assert.equal(status?.pill, "已连接");
+  assert.equal(status?.title, "Switch 已接受连接");
+  assert.equal(status?.authValue, true);
+  assert.equal(status?.connectedValue, true);
+  assert.equal(status?.readyValue, false);
+  assert.equal(status?.switchAcceptedValue, true);
+});
+
+test("deriveControllerStatus warns when the board firmware still reports hid-open-failed for a connecting HID open", () => {
+  const status = deriveControllerStatus([
+    "INFO transport=classic-bt-uartswitchcon",
+    "INFO bt_profile=uartswitchcon-pro-controller",
+    "INFO bt hid event=open status=0 conn=1 peer=unknown",
+    "INFO bt_discoverable=true",
+    "INFO bt_connected=false",
+    "INFO bt_auth_complete=false",
+    "INFO bt_paired=false",
+    "INFO bt_ready_for_reports=false",
+    "INFO bt_report_channel_open=false",
+    "INFO bt_init_step=hid-open-failed",
+    "INFO bt_init_error=hid_open_failed",
+  ]);
+
+  assert.ok(status);
+  assert.equal(status?.tone, "warning");
+  assert.equal(status?.pill, "待刷固件");
+  assert.equal(status?.title, "开发板固件需要更新");
+});
+
 test("shouldReuseExistingControllerConnection keeps active bluetooth sessions intact", () => {
   assert.equal(
     shouldReuseExistingControllerConnection({
@@ -116,6 +218,15 @@ test("shouldReuseExistingControllerConnection keeps active bluetooth sessions in
       connectedValue: false,
       authValue: true,
       discoverableValue: false,
+    }),
+    true,
+  );
+  assert.equal(
+    shouldReuseExistingControllerConnection({
+      readyValue: false,
+      connectedValue: false,
+      authValue: false,
+      initStep: "hid-connecting",
     }),
     true,
   );
@@ -150,6 +261,51 @@ test("shouldReuseExistingControllerConnection keeps active bluetooth sessions in
   );
 });
 
+test("shouldAutoReconnectLastPeer only retries the remembered host when a handshake already exists", () => {
+  assert.equal(
+    shouldAutoReconnectLastPeer({
+      readyValue: true,
+      connectedValue: false,
+      authValue: false,
+      pairedValue: false,
+      initStep: "discoverable",
+    }),
+    true,
+  );
+  assert.equal(
+    shouldAutoReconnectLastPeer({
+      readyValue: false,
+      connectedValue: false,
+      authValue: false,
+      pairedValue: false,
+      initStep: "hid-connecting",
+    }),
+    true,
+  );
+  assert.equal(
+    shouldAutoReconnectLastPeer({
+      readyValue: false,
+      connectedValue: false,
+      authValue: false,
+      pairedValue: false,
+      initStep: "discoverable",
+      peer: "78:81:8C:13:8E:D1",
+    }),
+    true,
+  );
+  assert.equal(
+    shouldAutoReconnectLastPeer({
+      readyValue: false,
+      connectedValue: false,
+      authValue: false,
+      pairedValue: false,
+      initStep: "discoverable",
+      peer: "-",
+    }),
+    false,
+  );
+});
+
 test("controller status updates also resync the controller action buttons", async () => {
   const appSource = await readFile(
     new URL("../src/web/static/app.js", import.meta.url),
@@ -168,7 +324,12 @@ test("controller status updates also resync the controller action buttons", asyn
 
   assert.match(
     appSource,
-    /state\.controller\.status\.reconnectRecommendedValue === true[\s\S]*BT RESET LAST-PEER[\s\S]*自动恢复手柄连接/u,
+    /els\.controllerResetButton\.addEventListener\("click", async \(\) => \{[\s\S]*shouldAutoReconnectLastPeer\(state\.controller\.status\)[\s\S]*BT RESET LAST-PEER[\s\S]*BT RESET[\s\S]*重置手柄蓝牙/u,
+  );
+
+  assert.match(
+    appSource,
+    /state\.controller\.status\.reconnectRecommendedValue === true[\s\S]*shouldAutoReconnectLastPeer\(state\.controller\.status\)[\s\S]*BT RESET LAST-PEER[\s\S]*BT RESET[\s\S]*自动恢复手柄连接/u,
   );
 
   assert.match(
@@ -178,7 +339,12 @@ test("controller status updates also resync the controller action buttons", asyn
 
   assert.match(
     appSource,
-    /controllerStatusTimeoutRecoveryAttempted = true[\s\S]*等待连接超过 45 秒，自动重置蓝牙并重试一次。[\s\S]*BT RESET LAST-PEER[\s\S]*自动恢复手柄连接/u,
+    /status\?\.switchAcceptedValue !== true[\s\S]*status\?\.readyValue !== true/u,
+  );
+
+  assert.match(
+    appSource,
+    /const shouldReconnectLastPeer = shouldAutoReconnectLastPeer\(state\.controller\.status\);[\s\S]*controllerStatusTimeoutRecoveryAttempted = true[\s\S]*等待连接超过 45 秒，自动重置蓝牙并重试一次。[\s\S]*BT RESET LAST-PEER[\s\S]*BT RESET[\s\S]*自动恢复手柄连接/u,
   );
 
   assert.match(

--- a/apps/desktop/test/execution-control.test.ts
+++ b/apps/desktop/test/execution-control.test.ts
@@ -79,3 +79,40 @@ test("SerialCommandSession waits for the port to stabilize before sending comman
     /waitForDeviceBoot\(this\.parser, port[\s\S]*serial_session=boot_ready[\s\S]*serial_session=boot_wait_skipped/u,
   );
 });
+
+test("controller page keeps the legacy 2000ms ACK compatibility path without changing studio defaults", async () => {
+  const appSource = await readFile(
+    new URL("../src/web/static/app.js", import.meta.url),
+    "utf8",
+  );
+
+  assert.match(appSource, /const CONTROLLER_COMPAT_ACK_TIMEOUT_MS = 2_000;/u);
+  assert.match(
+    appSource,
+    /commands:\s*\["I"\],[\s\S]*ackTimeoutMs:\s*CONTROLLER_COMPAT_ACK_TIMEOUT_MS,[\s\S]*enforceMinimumAckTimeout:\s*false/u,
+  );
+  assert.match(
+    appSource,
+    /runControllerCommands\([\s\S]*ackTimeoutMs:\s*CONTROLLER_COMPAT_ACK_TIMEOUT_MS,[\s\S]*enforceMinimumAckTimeout:\s*false/u,
+  );
+  assert.match(
+    appSource,
+    /async function runTimedSerialCommands\([\s\S]*ackTimeoutMs = state\.studio\.profile\.ackTimeoutMs,[\s\S]*enforceMinimumAckTimeout = true/u,
+  );
+});
+
+test("/api/execute keeps ACK timeout diagnostics and allows the controller compatibility override", async () => {
+  const serverSource = await readFile(
+    new URL("../src/web/server.ts", import.meta.url),
+    "utf8",
+  );
+
+  assert.match(serverSource, /export function resolveAckTimeoutMs\(/u);
+  assert.match(serverSource, /enforceMinimumAckTimeout\?: boolean/u);
+  assert.match(serverSource, /INFO ack_timeout_ms=\$\{ackTimeoutMs\}/u);
+  assert.match(serverSource, /INFO ack_timeout_floor_enforced=\$\{enforceMinimumAckTimeout \? "true" : "false"\}/u);
+  assert.match(
+    serverSource,
+    /const enforceMinimumAckTimeout = body\.enforceMinimumAckTimeout !== false;[\s\S]*resolveAckTimeoutMs\(body\.ackTimeoutMs, \{\s*enforceMinimum: enforceMinimumAckTimeout,/u,
+  );
+});

--- a/apps/desktop/test/execution-control.test.ts
+++ b/apps/desktop/test/execution-control.test.ts
@@ -1,4 +1,5 @@
 import assert from "node:assert/strict";
+import { readFile } from "node:fs/promises";
 import test from "node:test";
 
 import type {
@@ -57,4 +58,24 @@ test("ManagedSerialSessionSender.stop interrupts a blocking ACK wait and disconn
 
   await assert.rejects(sendPromise, /Execution stopped/u);
   assert.equal(disconnectCalls, 1);
+});
+
+test("SerialCommandSession waits for the port to stabilize before sending commands", async () => {
+  const senderSource = await readFile(
+    new URL("../src/serial/sender.ts", import.meta.url),
+    "utf8",
+  );
+
+  assert.match(
+    senderSource,
+    /SERIAL_OPEN_STABILIZE_DELAY_MS = 500[\s\S]*SERIAL_OPEN_BOOT_TIMEOUT_MS = 12_000/u,
+  );
+  assert.match(
+    senderSource,
+    /setPortSignals\(port, \{ dtr: false, rts: false, brk: false \}\)[\s\S]*serial_session=stabilizing/u,
+  );
+  assert.match(
+    senderSource,
+    /waitForDeviceBoot\(this\.parser, port[\s\S]*serial_session=boot_ready[\s\S]*serial_session=boot_wait_skipped/u,
+  );
 });

--- a/apps/desktop/test/firmware-flash.test.ts
+++ b/apps/desktop/test/firmware-flash.test.ts
@@ -101,6 +101,14 @@ test("controller firmware keeps bluetooth identity stable and waits for host HID
     firmwareSource,
     /deriveDeterministicBaseMac[\s\S]*source=%s/u,
   );
+  assert.match(
+    firmwareSource,
+    /esp_base_mac_addr_set\(baseMac\)[\s\S]*esp_read_mac\(bluetoothMac, ESP_MAC_BT\)[\s\S]*rememberLocalControllerAddress\(bluetoothMac\)/u,
+  );
+  assert.match(
+    firmwareSource,
+    /INFO bt_reply02_mac=[\s\S]*formatBluetoothAddress\(&kReply02\[18\]\)/u,
+  );
   assert.doesNotMatch(
     firmwareSource,
     /ESP_BT_GAP_AUTH_CMPL_EVT[\s\S]*attemptVirtualCablePlug\(lastPeerAddress_, "auth-complete"\)/u,
@@ -116,5 +124,17 @@ test("controller firmware keeps bluetooth identity stable and waits for host HID
   assert.doesNotMatch(
     firmwareSource,
     /else if \(hasPeerAddress_\)[\s\S]*attemptVirtualCablePlug\(lastPeerAddress_, "register-app-last-peer"\)/u,
+  );
+  assert.match(
+    firmwareSource,
+    /ESP_HIDD_OPEN_EVT[\s\S]*ESP_HIDD_CONN_STATE_CONNECTING[\s\S]*initStep_ = "hid-connecting"/u,
+  );
+  assert.match(
+    firmwareSource,
+    /sendCurrentInputReport\(bool logFailure, bool waitForSendEvent\)[\s\S]*const uint8_t \*payload = report30_[\s\S]*const size_t payloadLength = sizeof\(report30_\)/u,
+  );
+  assert.doesNotMatch(
+    firmwareSource,
+    /sendCurrentInputReport\(bool logFailure, bool waitForSendEvent\)[\s\S]*dummyReport_/u,
   );
 });

--- a/apps/desktop/test/three-layer-fix.test.ts
+++ b/apps/desktop/test/three-layer-fix.test.ts
@@ -358,6 +358,7 @@ test("dynamic timeouts follow CFG INPUT timing", () => {
   assert.equal(getAckTimeoutForCommand("M 3 0", 500, timing), 1600);
   assert.equal(getAckTimeoutForCommand("L 3 0", 500, timing), 1800);
   assert.equal(getAckTimeoutForCommand("H", 500, timing), 4700);
+  assert.equal(getAckTimeoutForCommand("BT RESET LAST-PEER", 500, timing), 20_000);
 });
 
 test("palette-config commands get enough timeout for calibrated custom colors", () => {

--- a/apps/desktop/test/timing-config.test.ts
+++ b/apps/desktop/test/timing-config.test.ts
@@ -12,7 +12,7 @@ import { loadProfile } from "../src/config/loadProfile.js";
 import { generateScanlinePlan } from "../src/path/scanline.js";
 import { serializeCommands } from "../src/protocol/serializer.js";
 import type { DrawingProfile, Pixel, PixelMap } from "../src/types.js";
-import { startWebServer } from "../src/web/server.js";
+import { resolveAckTimeoutMs, startWebServer } from "../src/web/server.js";
 
 function makeProfile(overrides: Partial<DrawingProfile> = {}): DrawingProfile {
   return {
@@ -173,4 +173,11 @@ test("loadProfile clamps legacy ack timeout values to the supported minimum", as
   const profile = await loadProfile(profilePath);
 
   assert.equal(profile.ackTimeoutMs, DEFAULT_ACK_TIMEOUT_MS);
+});
+
+test("resolveAckTimeoutMs keeps the global floor by default but allows controller compatibility overrides", () => {
+  assert.equal(resolveAckTimeoutMs(2_000), DEFAULT_ACK_TIMEOUT_MS);
+  assert.equal(resolveAckTimeoutMs(undefined), DEFAULT_ACK_TIMEOUT_MS);
+  assert.equal(resolveAckTimeoutMs(2_000, { enforceMinimum: false }), 2_000);
+  assert.equal(resolveAckTimeoutMs(undefined, { enforceMinimum: false }), DEFAULT_ACK_TIMEOUT_MS);
 });

--- a/firmware/esp32/src/classic_bt_controller_transport.cpp
+++ b/firmware/esp32/src/classic_bt_controller_transport.cpp
@@ -236,6 +236,13 @@ void ClassicBtControllerTransport::begin() {
   }
 }
 
+void ClassicBtControllerTransport::rememberLocalControllerAddress(
+    const uint8_t bluetoothAddress[6]) {
+  std::memcpy(localControllerAddress_, bluetoothAddress, sizeof(localControllerAddress_));
+  hasLocalControllerAddress_ = true;
+  std::memcpy(&kReply02[18], bluetoothAddress, sizeof(localControllerAddress_));
+}
+
 bool ClassicBtControllerTransport::initializeNvsAndBaseAddress() {
   esp_err_t err = nvs_flash_init();
   if (err == ESP_ERR_NVS_NO_FREE_PAGES || err == ESP_ERR_NVS_NEW_VERSION_FOUND) {
@@ -295,6 +302,14 @@ bool ClassicBtControllerTransport::initializeNvsAndBaseAddress() {
     Serial.printf("WARN base_mac_set failed err=%s\n", esp_err_to_name(err));
     return false;
   }
+
+  uint8_t bluetoothMac[6] = {};
+  err = esp_read_mac(bluetoothMac, ESP_MAC_BT);
+  if (err != ESP_OK) {
+    Serial.printf("WARN bt read_mac failed err=%s\n", esp_err_to_name(err));
+    return false;
+  }
+  rememberLocalControllerAddress(bluetoothMac);
 
   Serial.printf(
       "INFO bt base_mac=%02X:%02X:%02X:%02X:%02X:%02X source=%s\n",
@@ -500,10 +515,6 @@ void ClassicBtControllerTransport::clearInputs() {
   std::memset(report30_, 0, sizeof(report30_));
   report30_[1] = 0x8E;
   report30_[11] = 0x80;
-
-  const uint8_t defaultDummy[] = {0x00, 0x8E, 0x00, 0x00, 0x00, 0x00,
-                                  0x08, 0x80, 0x00, 0x08, 0x80};
-  std::memcpy(dummyReport_, defaultDummy, sizeof(dummyReport_));
   updateInputReport();
 }
 
@@ -586,8 +597,6 @@ void ClassicBtControllerTransport::updateInputReport() {
   report30_[8] = static_cast<uint8_t>((rightStickX_ << 4) & 0xF0);
   report30_[9] = static_cast<uint8_t>((rightStickX_ & 0xF0) >> 4);
   report30_[10] = rightStickY_;
-
-  dummyReport_[0] = timer_;
 }
 
 void ClassicBtControllerTransport::ensureSendTask() {
@@ -699,6 +708,8 @@ void ClassicBtControllerTransport::enterReconnectableState(const char *reason) {
   reportCongested_ = false;
   consecutiveSendReportFailures_ = 0;
   lastDropReason_ = reason;
+  initStep_ = "discoverable";
+  initError_ = "ESP_OK";
   clearInputs();
 
   esp_err_t err = ESP_OK;
@@ -739,6 +750,8 @@ void ClassicBtControllerTransport::printStatus(Print &output) const {
   output.println(boolName(paired_));
   output.print("INFO bt_ready_for_reports=");
   output.println(boolName(isControllerInputReady()));
+  output.print("INFO bt_report_channel_open=");
+  output.println(boolName(isHidReportChannelOpen()));
   output.print("INFO bt_init_step=");
   output.println(initStep_);
   output.print("INFO bt_init_error=");
@@ -770,6 +783,12 @@ void ClassicBtControllerTransport::printStatus(Print &output) const {
     output.print("INFO bt_last_peer=");
     output.println(formatBluetoothAddress(lastPeerAddress_));
   }
+  if (hasLocalControllerAddress_) {
+    output.print("INFO bt_local_mac=");
+    output.println(formatBluetoothAddress(localControllerAddress_));
+    output.print("INFO bt_reply02_mac=");
+    output.println(formatBluetoothAddress(&kReply02[18]));
+  }
 }
 
 const char *ClassicBtControllerTransport::name() const { return CONTROL_TRANSPORT; }
@@ -799,9 +818,8 @@ bool ClassicBtControllerTransport::sendCurrentInputReport(bool logFailure, bool 
 
   const bool shouldWaitForSendEvent = waitForSendEvent && paired_;
   uint32_t expectedEventCount = 0;
-  const bool shouldSendFullReport = connected_ || paired_;
-  const uint8_t *payload = shouldSendFullReport ? report30_ : dummyReport_;
-  const size_t payloadLength = shouldSendFullReport ? sizeof(report30_) : sizeof(dummyReport_);
+  const uint8_t *payload = report30_;
+  const size_t payloadLength = sizeof(report30_);
 
   if (inputReportSendMutex_ != nullptr) {
     xSemaphoreTakeRecursive(inputReportSendMutex_, portMAX_DELAY);
@@ -990,6 +1008,9 @@ void ClassicBtControllerTransport::markControllerPaired() {
   }
   paired_ = true;
   pairingComplete_ = true;
+  initStep_ = "paired";
+  initError_ = "ESP_OK";
+  lastDropReason_ = "none";
 }
 
 bool ClassicBtControllerTransport::sendSubcommandReply(
@@ -1147,6 +1168,8 @@ void ClassicBtControllerTransport::handleGapEvent(int event, void *rawParam) {
   switch (gapEvent) {
     case ESP_BT_GAP_AUTH_CMPL_EVT:
       authComplete_ = param->auth_cmpl.stat == ESP_BT_STATUS_SUCCESS;
+      initStep_ = authComplete_ ? "auth-complete" : "auth-failed";
+      initError_ = authComplete_ ? "ESP_OK" : "auth_failed";
       Serial.printf(
           "INFO bt auth status=%d device=\"%s\"\n",
           param->auth_cmpl.stat,
@@ -1154,6 +1177,7 @@ void ClassicBtControllerTransport::handleGapEvent(int event, void *rawParam) {
       if (param->auth_cmpl.stat == ESP_BT_STATUS_SUCCESS) {
         std::memcpy(lastPeerAddress_, param->auth_cmpl.bda, sizeof(lastPeerAddress_));
         hasPeerAddress_ = true;
+        lastDropReason_ = "none";
         // Let Switch initiate the HID control channel after authentication.
         // Proactively opening a virtual cable here can race with the host's own
         // incoming CTRL connection and trigger invalid-state rejects.
@@ -1231,6 +1255,18 @@ void ClassicBtControllerTransport::handleHidEvent(int event, void *rawParam) {
     case ESP_HIDD_OPEN_EVT:
       connected_ = param->open.status == ESP_HIDD_SUCCESS &&
                    param->open.conn_status == ESP_HIDD_CONN_STATE_CONNECTED;
+      if (connected_) {
+        initStep_ = "hid-open";
+        initError_ = "ESP_OK";
+      } else if (
+          param->open.status == ESP_HIDD_SUCCESS &&
+          param->open.conn_status == ESP_HIDD_CONN_STATE_CONNECTING) {
+        initStep_ = "hid-connecting";
+        initError_ = "ESP_OK";
+      } else {
+        initStep_ = "hid-open-failed";
+        initError_ = "hid_open_failed";
+      }
       readyForReports_ = connected_ && appRegistered_ && hidReady_;
       discoverable_ = !connected_;
       reportCongested_ = false;
@@ -1238,6 +1274,7 @@ void ClassicBtControllerTransport::handleHidEvent(int event, void *rawParam) {
       if (connected_) {
         std::memcpy(lastPeerAddress_, param->open.bd_addr, sizeof(lastPeerAddress_));
         hasPeerAddress_ = true;
+        lastDropReason_ = "none";
         esp_bt_gap_set_scan_mode(ESP_BT_NON_CONNECTABLE, ESP_BT_NON_DISCOVERABLE);
         ensureSendTask();
         sendCurrentInputReport(false);
@@ -1396,6 +1433,10 @@ const char *ClassicBtControllerTransport::name() const { return CONTROL_TRANSPOR
 
 bool ClassicBtControllerTransport::initializeClassicBluetooth() { return false; }
 bool ClassicBtControllerTransport::initializeNvsAndBaseAddress() { return false; }
+void ClassicBtControllerTransport::rememberLocalControllerAddress(
+    const uint8_t bluetoothAddress[6]) {
+  (void)bluetoothAddress;
+}
 void ClassicBtControllerTransport::clearInputs() {}
 void ClassicBtControllerTransport::setButtonBits(uint32_t buttonsMask) { (void)buttonsMask; }
 void ClassicBtControllerTransport::setLeftStickFromVector(int x, int y) {

--- a/firmware/esp32/src/classic_bt_controller_transport.h
+++ b/firmware/esp32/src/classic_bt_controller_transport.h
@@ -19,6 +19,7 @@ class ClassicBtControllerTransport : public ControllerTransport {
   bool initializeClassicBluetooth();
   bool initializeNvsAndBaseAddress();
   bool shutdownClassicBluetooth();
+  void rememberLocalControllerAddress(const uint8_t bluetoothAddress[6]);
   void clearConnectionState();
   void clearInputs();
   void setButtonBits(uint32_t buttonsMask);
@@ -72,7 +73,6 @@ class ClassicBtControllerTransport : public ControllerTransport {
   uint8_t rightStickX_ = 128;
   uint8_t rightStickY_ = 128;
   uint8_t report30_[48] = {};
-  uint8_t dummyReport_[11] = {};
   SemaphoreHandle_t inputReportSendMutex_ = nullptr;
   TaskHandle_t sendTaskHandle_ = nullptr;
   volatile bool explicitInputActive_ = false;
@@ -80,6 +80,8 @@ class ClassicBtControllerTransport : public ControllerTransport {
   volatile uint32_t inputReportSendEventCount_ = 0;
   volatile int lastInputReportStatus_ = -1;
   volatile uint8_t lastInputReportReason_ = 0;
+  uint8_t localControllerAddress_[6] = {};
+  bool hasLocalControllerAddress_ = false;
   uint8_t lastPeerAddress_[6] = {};
   bool hasPeerAddress_ = false;
   bool reconnectLastPeerOnRegister_ = false;


### PR DESCRIPTION
## 中文

### 变更
- 修复 ESP32 模拟手柄连接 Switch 时，Switch 已提示“已匹配/已连接”，但程序端长期不进入“匹配成功/已就绪”的问题
- 同步 `reply02` 中的 device-info MAC 与真实蓝牙 MAC，降低身份不一致导致的首配、回连不稳定
- 优化串口打开后的稳定等待流程，减少首条命令因为设备尚未 ready 而超时的情况
- 改进前端状态识别，区分“Switch 已接受连接”“已就绪”“身份异常”等状态
- 修复 `bt_local_mac` 瞬时空值导致的“身份不一致”误报

### 测试
- `npm run check`
- `node --import tsx --test apps/desktop/test/controller-status.test.ts`

## English

### Changes
- Fix the issue where Switch shows the controller as paired/connected, but the app does not reach the paired/ready state
- Sync the `reply02` device-info MAC with the actual Bluetooth MAC to reduce unstable pairing and reconnect behavior caused by identity mismatch
- Add a serial startup stabilization step after opening the port to reduce first-command timeouts before the device is ready
- Improve frontend status parsing to distinguish “Switch accepted connection”, “ready”, and “identity mismatch”
- Fix false identity-mismatch warnings caused by transient empty `bt_local_mac` reads

### Testing
- `npm run check`
- `node --import tsx --test apps/desktop/test/controller-status.test.ts`
