### PR TITLE
[codex] Add optional noise cleanup preprocessing

### DIFF
--- a/apps/desktop/src/app/generateDrawPlan.ts
+++ b/apps/desktop/src/app/generateDrawPlan.ts
@@ -5,7 +5,15 @@ import { renderPreviewToBuffer } from "../image/renderPreview.js";
 import { estimateRuntimeMs, generateScanlinePlan, type PathStrategy } from "../path/scanline.js";
 import { serializeCommands } from "../protocol/serializer.js";
 import type { DrawCommand } from "../protocol/commands.js";
-import type { CanvasBounds, DrawingMask, DrawingProfile, PixelMap, ResumePlan } from "../types.js";
+import type {
+  CanvasBounds,
+  DrawingMask,
+  DrawingProfile,
+  NoiseCleanupMode,
+  NoiseCleanupStats,
+  PixelMap,
+  ResumePlan,
+} from "../types.js";
 
 export interface DrawPlanPathStats {
   lineRunCount: number;
@@ -26,6 +34,7 @@ export interface DrawPlan {
   previewPng: Buffer;
   imageBounds: CanvasBounds | null;
   pathStats: DrawPlanPathStats;
+  noiseCleanupStats: NoiseCleanupStats;
 }
 
 export async function generateDrawPlan(
@@ -39,9 +48,10 @@ export async function generateDrawPlan(
     removeBackground?: boolean;
     drawingMask?: DrawingMask | null;
     pathStrategy?: PathStrategy;
+    noiseCleanupMode?: NoiseCleanupMode;
   },
 ): Promise<DrawPlan> {
-  const { pixelMap, usedColorIndexes } = await pixelizeImage(imageSource, profile, options);
+  const { pixelMap, usedColorIndexes, noiseCleanupStats } = await pixelizeImage(imageSource, profile, options);
   const previewPng = await renderPreviewToBuffer(pixelMap, profile, previewScale);
   const scanlinePlan = generateScanlinePlan(pixelMap, profile, options?.pathStrategy);
   const drawCommands = scanlinePlan.commands;
@@ -71,6 +81,7 @@ export async function generateDrawPlan(
     previewPng,
     imageBounds,
     pathStats,
+    noiseCleanupStats,
   };
 }
 

--- a/apps/desktop/src/image/noiseCleanup.ts
+++ b/apps/desktop/src/image/noiseCleanup.ts
@@ -1,0 +1,334 @@
+import type {
+  NoiseCleanupMode,
+  NoiseCleanupStats,
+  Pixel,
+  PixelMap,
+  PixelMapNoiseStats,
+  RgbColor,
+} from "../types.js";
+import { colorDistanceSquared, parseHexColor } from "../utils/colors.js";
+
+export const NOISE_CLEANUP_THRESHOLDS: Record<NoiseCleanupMode, number> = {
+  off: 0,
+  light: 4,
+  standard: 12,
+  strong: 24,
+};
+
+const NEIGHBOR_OFFSETS = [
+  { dx: 1, dy: 0 },
+  { dx: -1, dy: 0 },
+  { dx: 0, dy: 1 },
+  { dx: 0, dy: -1 },
+] as const;
+
+interface NoiseComponent {
+  colorIndex: number;
+  colorHex: string;
+  pixels: Pixel[];
+  keys: Set<string>;
+}
+
+interface NeighborCandidate {
+  colorIndex: number;
+  colorHex: string;
+  count: number;
+  distance: number;
+}
+
+export interface CleanupPixelMapNoiseOptions {
+  mode?: NoiseCleanupMode;
+  thresholdCells?: number;
+}
+
+export interface CleanupPixelMapNoiseResult {
+  pixelMap: PixelMap;
+  stats: NoiseCleanupStats;
+}
+
+export function cleanupPixelMapNoise(
+  pixelMap: PixelMap,
+  options: CleanupPixelMapNoiseOptions = {},
+): CleanupPixelMapNoiseResult {
+  const mode = options.mode ?? "off";
+  const thresholdCells = mode === "off"
+    ? 0
+    : Math.max(0, Math.floor(options.thresholdCells ?? NOISE_CLEANUP_THRESHOLDS[mode]));
+  const before = calculatePixelMapNoiseStats(pixelMap, thresholdCells);
+
+  if (thresholdCells <= 0) {
+    const cloned = clonePixelMap(pixelMap);
+
+    return {
+      pixelMap: cloned,
+      stats: {
+        mode,
+        thresholdCells,
+        changedCellCount: 0,
+        before,
+        after: before,
+      },
+    };
+  }
+
+  const components = collectNoiseComponents(pixelMap);
+  const output = clonePixelMap(pixelMap);
+
+  for (const component of components) {
+    if (component.pixels.length >= thresholdCells) {
+      continue;
+    }
+
+    const target = chooseNeighborMergeTarget(pixelMap, component);
+
+    if (!target) {
+      continue;
+    }
+
+    for (const pixel of component.pixels) {
+      const outputPixel = output[pixel.y]?.[pixel.x];
+
+      if (!outputPixel) {
+        continue;
+      }
+
+      outputPixel.colorIndex = target.colorIndex;
+      outputPixel.colorHex = target.colorHex;
+    }
+  }
+
+  const after = calculatePixelMapNoiseStats(output, thresholdCells);
+
+  return {
+    pixelMap: output,
+    stats: {
+      mode,
+      thresholdCells,
+      changedCellCount: countChangedCells(pixelMap, output),
+      before,
+      after,
+    },
+  };
+}
+
+export function calculatePixelMapNoiseStats(
+  pixelMap: PixelMap,
+  thresholdCells: number,
+): PixelMapNoiseStats {
+  const usedColorIndexes = new Set<number>();
+  let drawableCellCount = 0;
+  let tinyComponentCount = 0;
+  const components = collectNoiseComponents(pixelMap);
+
+  for (const component of components) {
+    usedColorIndexes.add(component.colorIndex);
+    drawableCellCount += component.pixels.length;
+
+    if (thresholdCells > 0 && component.pixels.length < thresholdCells) {
+      tinyComponentCount += 1;
+    }
+  }
+
+  return {
+    thresholdCells,
+    usedColorCount: usedColorIndexes.size,
+    drawableCellCount,
+    connectedComponentCount: components.length,
+    tinyComponentCount,
+  };
+}
+
+export function getNoiseCleanupThresholdCells(mode: NoiseCleanupMode): number {
+  return NOISE_CLEANUP_THRESHOLDS[mode];
+}
+
+function clonePixelMap(pixelMap: PixelMap): PixelMap {
+  return pixelMap.map((row) => row.map((pixel) => ({ ...pixel })));
+}
+
+function countChangedCells(before: PixelMap, after: PixelMap): number {
+  let changed = 0;
+
+  for (let y = 0; y < before.length; y += 1) {
+    const beforeRow = before[y] ?? [];
+    const afterRow = after[y] ?? [];
+
+    for (let x = 0; x < beforeRow.length; x += 1) {
+      const beforePixel = beforeRow[x];
+      const afterPixel = afterRow[x];
+
+      if (!beforePixel || !afterPixel) {
+        continue;
+      }
+
+      if (
+        beforePixel.colorIndex !== afterPixel.colorIndex ||
+        beforePixel.colorHex !== afterPixel.colorHex ||
+        beforePixel.alpha !== afterPixel.alpha
+      ) {
+        changed += 1;
+      }
+    }
+  }
+
+  return changed;
+}
+
+function collectNoiseComponents(pixelMap: PixelMap): NoiseComponent[] {
+  const visited = new Set<string>();
+  const components: NoiseComponent[] = [];
+
+  for (let y = 0; y < pixelMap.length; y += 1) {
+    const row = pixelMap[y] ?? [];
+
+    for (let x = 0; x < row.length; x += 1) {
+      const pixel = row[x];
+
+      if (!pixel || !isDrawable(pixel)) {
+        continue;
+      }
+
+      const startKey = pixelKey(pixel);
+
+      if (visited.has(startKey)) {
+        continue;
+      }
+
+      const stack = [pixel];
+      const pixels: Pixel[] = [];
+      const keys = new Set<string>();
+      visited.add(startKey);
+
+      while (stack.length > 0) {
+        const current = stack.pop()!;
+        const currentKey = pixelKey(current);
+        pixels.push(current);
+        keys.add(currentKey);
+
+        for (const offset of NEIGHBOR_OFFSETS) {
+          const neighbor = getPixel(pixelMap, current.x + offset.dx, current.y + offset.dy);
+
+          if (!neighbor || !isDrawable(neighbor) || neighbor.colorIndex !== pixel.colorIndex) {
+            continue;
+          }
+
+          const neighborKey = pixelKey(neighbor);
+
+          if (visited.has(neighborKey)) {
+            continue;
+          }
+
+          visited.add(neighborKey);
+          stack.push(neighbor);
+        }
+      }
+
+      components.push({
+        colorIndex: pixel.colorIndex,
+        colorHex: pixel.colorHex,
+        pixels,
+        keys,
+      });
+    }
+  }
+
+  return components;
+}
+
+function chooseNeighborMergeTarget(
+  pixelMap: PixelMap,
+  component: NoiseComponent,
+): { colorIndex: number; colorHex: string } | null {
+  const componentRgb = parseRgb(component.colorHex);
+  const borderPixels = new Map<string, Pixel>();
+
+  for (const pixel of component.pixels) {
+    for (const offset of NEIGHBOR_OFFSETS) {
+      const neighbor = getPixel(pixelMap, pixel.x + offset.dx, pixel.y + offset.dy);
+
+      if (!neighbor || !isDrawable(neighbor) || component.keys.has(pixelKey(neighbor))) {
+        continue;
+      }
+
+      borderPixels.set(pixelKey(neighbor), neighbor);
+    }
+  }
+
+  const candidatesByColor = new Map<number, NeighborCandidate>();
+
+  for (const neighbor of Array.from(borderPixels.values()).sort(comparePixelPosition)) {
+    const rgb = parseRgb(neighbor.colorHex);
+    const existing = candidatesByColor.get(neighbor.colorIndex);
+
+    if (existing) {
+      existing.count += 1;
+      continue;
+    }
+
+    candidatesByColor.set(neighbor.colorIndex, {
+      colorIndex: neighbor.colorIndex,
+      colorHex: neighbor.colorHex,
+      count: 1,
+      distance: colorDistanceSquared(componentRgb, rgb),
+    });
+  }
+
+  const candidates = Array.from(candidatesByColor.values());
+
+  if (candidates.length === 0) {
+    return null;
+  }
+
+  candidates.sort((left, right) => {
+    if (left.count !== right.count) {
+      return right.count - left.count;
+    }
+
+    if (left.distance !== right.distance) {
+      return left.distance - right.distance;
+    }
+
+    if (left.colorIndex !== right.colorIndex) {
+      return left.colorIndex - right.colorIndex;
+    }
+
+    return left.colorHex.localeCompare(right.colorHex);
+  });
+
+  const target = candidates[0];
+
+  return target
+    ? {
+        colorIndex: target.colorIndex,
+        colorHex: target.colorHex,
+      }
+    : null;
+}
+
+function isDrawable(pixel: Pixel): boolean {
+  return pixel.alpha > 0 && pixel.colorIndex >= 0;
+}
+
+function getPixel(pixelMap: PixelMap, x: number, y: number): Pixel | null {
+  return pixelMap[y]?.[x] ?? null;
+}
+
+function pixelKey(point: { x: number; y: number }): string {
+  return `${point.x},${point.y}`;
+}
+
+function comparePixelPosition(left: Pixel, right: Pixel): number {
+  if (left.y !== right.y) {
+    return left.y - right.y;
+  }
+
+  return left.x - right.x;
+}
+
+function parseRgb(hex: string): RgbColor {
+  try {
+    return parseHexColor(hex);
+  } catch {
+    return { r: 0, g: 0, b: 0 };
+  }
+}

--- a/apps/desktop/src/image/pixelize.ts
+++ b/apps/desktop/src/image/pixelize.ts
@@ -1,4 +1,4 @@
-import type { DrawingMask, DrawingProfile, PixelizationResult } from "../types.js";
+import type { DrawingMask, DrawingProfile, NoiseCleanupMode, PixelMap, PixelizationResult } from "../types.js";
 import { createBrushGrid } from "../brushGrid.js";
 import type { ImageSource } from "./loadImage.js";
 import {
@@ -10,6 +10,7 @@ import {
 import { autoRemoveBackground } from "./removeBackground.js";
 import { resizeImage } from "./resizeImage.js";
 import { quantizePixels } from "./quantize.js";
+import { cleanupPixelMapNoise } from "./noiseCleanup.js";
 
 function collapsePixelMapForBrush(
   pixelMap: PixelizationResult["pixelMap"],
@@ -135,6 +136,16 @@ function collapsePixelMapForBrush(
   return collapsed;
 }
 
+function collectUsedColorIndexes(pixelMap: PixelMap): number[] {
+  return Array.from(
+    new Set(
+      pixelMap.flatMap((row) =>
+        row.filter((pixel) => pixel.alpha > 0 && pixel.colorIndex >= 0).map((pixel) => pixel.colorIndex),
+      ),
+    ),
+  ).sort((a, b) => a - b);
+}
+
 export async function pixelizeImage(
   imageSource: ImageSource,
   profile: DrawingProfile,
@@ -144,6 +155,7 @@ export async function pixelizeImage(
     imageOffsetYPercent?: number;
     removeBackground?: boolean;
     drawingMask?: DrawingMask | null;
+    noiseCleanupMode?: NoiseCleanupMode;
   },
 ): Promise<PixelizationResult> {
   const grid = createBrushGrid(profile);
@@ -172,18 +184,16 @@ export async function pixelizeImage(
     monoThreshold: profile.monoThreshold,
     palette: profile.palette,
   });
-  const pixelMap = collapsePixelMapForBrush(fullPixelMap, profile, drawingMaskCoverageMap);
-
-  const usedColorIndexes = Array.from(
-    new Set(
-      pixelMap.flatMap((row) =>
-        row.filter((pixel) => pixel.alpha > 0 && pixel.colorIndex >= 0).map((pixel) => pixel.colorIndex),
-      ),
-    ),
-  ).sort((a, b) => a - b);
+  const collapsedPixelMap = collapsePixelMapForBrush(fullPixelMap, profile, drawingMaskCoverageMap);
+  const cleanupResult = cleanupPixelMapNoise(collapsedPixelMap, {
+    mode: options?.noiseCleanupMode ?? "off",
+  });
+  const pixelMap = cleanupResult.pixelMap;
+  const usedColorIndexes = collectUsedColorIndexes(pixelMap);
 
   return {
     pixelMap,
     usedColorIndexes,
+    noiseCleanupStats: cleanupResult.stats,
   };
 }

--- a/apps/desktop/src/types.ts
+++ b/apps/desktop/src/types.ts
@@ -4,6 +4,7 @@ export type ControllerButton = "A" | "B" | "X" | "Y";
 export type StartCursor = "center" | "top-left";
 export type DrawingTool = "pen" | "eraser" | "fill" | "stamp" | "text" | "shape";
 export type BrushSize = 1 | 3 | 7 | 13 | 19 | 27;
+export type NoiseCleanupMode = "off" | "light" | "standard" | "strong";
 
 export interface RgbColor {
   r: number;
@@ -64,6 +65,23 @@ export interface DrawingProfile {
 export interface PixelizationResult {
   pixelMap: PixelMap;
   usedColorIndexes: number[];
+  noiseCleanupStats: NoiseCleanupStats;
+}
+
+export interface PixelMapNoiseStats {
+  thresholdCells: number;
+  usedColorCount: number;
+  drawableCellCount: number;
+  connectedComponentCount: number;
+  tinyComponentCount: number;
+}
+
+export interface NoiseCleanupStats {
+  mode: NoiseCleanupMode;
+  thresholdCells: number;
+  changedCellCount: number;
+  before: PixelMapNoiseStats;
+  after: PixelMapNoiseStats;
 }
 
 export interface CanvasBounds {

--- a/apps/desktop/src/web/server.ts
+++ b/apps/desktop/src/web/server.ts
@@ -31,7 +31,7 @@ import {
   type SerialSessionSnapshot,
 } from "../serial/sender.js";
 import { SimulatedAckSender } from "../simulator/sender.js";
-import type { ResumePlan, SenderControls } from "../types.js";
+import type { NoiseCleanupMode, ResumePlan, SenderControls } from "../types.js";
 import {
   RecoverySessionStore,
   applyRecoveryProgress,
@@ -83,6 +83,15 @@ const FIRMWARE_FLASH_CANCEL_GRACE_MS = 5_000;
 function normalizeAckTimeoutMs(value?: number): number {
   return Math.max(value ?? DEFAULT_ACK_TIMEOUT_MS, DEFAULT_ACK_TIMEOUT_MS);
 }
+
+const VALID_NOISE_CLEANUP_MODES = new Set<NoiseCleanupMode>(["off", "light", "standard", "strong"]);
+
+function normalizeNoiseCleanupMode(value: unknown): NoiseCleanupMode {
+  return typeof value === "string" && VALID_NOISE_CLEANUP_MODES.has(value as NoiseCleanupMode)
+    ? (value as NoiseCleanupMode)
+    : "off";
+}
+
 const serialSessionManager = new SerialSessionManager();
 
 export interface StartWebServerOptions {
@@ -1051,6 +1060,7 @@ async function handleGenerate(request: IncomingMessage, response: ServerResponse
     palette?: string[];
     previewScale?: number;
     removeBackground?: boolean;
+    noiseCleanupMode?: NoiseCleanupMode;
     inputDelay?: number;
     buttonPressDuration?: number;
   };
@@ -1079,6 +1089,7 @@ async function handleGenerate(request: IncomingMessage, response: ServerResponse
   const imageScalePercent = normalizeImageScalePercent(body.imageScalePercent);
   const imageOffsetXPercent = normalizeImageOffsetPercent(body.imageOffsetXPercent);
   const imageOffsetYPercent = normalizeImageOffsetPercent(body.imageOffsetYPercent);
+  const noiseCleanupMode = normalizeNoiseCleanupMode(body.noiseCleanupMode);
   const template = getDrawingTemplateDefinition(body.templateId ?? "none");
 
   if (!template) {
@@ -1107,6 +1118,7 @@ async function handleGenerate(request: IncomingMessage, response: ServerResponse
       imageOffsetYPercent,
       removeBackground: body.removeBackground === true,
       drawingMask,
+      noiseCleanupMode,
     },
   );
 
@@ -1124,6 +1136,7 @@ async function handleGenerate(request: IncomingMessage, response: ServerResponse
       colorMode: profile.colorMode,
       colorCount: profile.colorCount,
       removeBackground: body.removeBackground === true,
+      noiseCleanupMode,
       palette: plan.paletteHexes,
       baudRate: profile.baudRate,
       ackTimeoutMs: profile.ackTimeoutMs,
@@ -1140,6 +1153,7 @@ async function handleGenerate(request: IncomingMessage, response: ServerResponse
       estimatedRuntimeLabel: formatDuration(plan.estimatedRuntimeMs),
       imageBounds: plan.imageBounds,
       pathStats: plan.pathStats,
+      noiseCleanup: plan.noiseCleanupStats,
     },
     previewDataUrl: `data:image/png;base64,${plan.previewPng.toString("base64")}`,
     commands: plan.commands,

--- a/apps/desktop/src/web/static/app.js
+++ b/apps/desktop/src/web/static/app.js
@@ -78,6 +78,7 @@ const state = {
     previewGuideMode: "none",
     colorMode: "mono",
     colorCount: 32,
+    noiseCleanupMode: "off",
     removeBackground: false,
     usedColorIndexes: [],
     generatedPalette: [],
@@ -217,6 +218,7 @@ const els = {
   templatePreviewLabel: document.getElementById("template-preview-label"),
   colorModeSelect: document.getElementById("color-mode-select"),
   colorCountSelect: document.getElementById("color-count-select"),
+  noiseCleanupSelect: document.getElementById("noise-cleanup-select"),
   thresholdLabel: document.getElementById("threshold-label"),
   thresholdRange: document.getElementById("threshold-range"),
   thresholdValue: document.getElementById("threshold-value"),
@@ -530,6 +532,16 @@ els.colorModeSelect.addEventListener("change", () => {
 
 els.colorCountSelect.addEventListener("change", () => {
   state.studio.colorCount = Number(els.colorCountSelect.value || state.studio.colorCount);
+  syncStudioUi();
+  scheduleStudioPreviewRefresh();
+});
+
+els.noiseCleanupSelect.addEventListener("change", () => {
+  const nextMode = els.noiseCleanupSelect.value;
+  state.studio.noiseCleanupMode =
+    nextMode === "light" || nextMode === "standard" || nextMode === "strong"
+      ? nextMode
+      : "off";
   syncStudioUi();
   scheduleStudioPreviewRefresh();
 });
@@ -962,6 +974,7 @@ function buildStudioGeneratePayload() {
     threshold: Number(els.thresholdRange.value),
     previewScale: 12,
     removeBackground: state.studio.removeBackground,
+    noiseCleanupMode: state.studio.noiseCleanupMode,
     inputDelay: state.sharedTiming.inputDelay,
     buttonPressDuration: state.sharedTiming.buttonPressDuration,
   };
@@ -1020,6 +1033,12 @@ function applyGeneratedStudioPayload(payload) {
       ? payload.profile.colorMode
       : "mono";
   state.studio.colorCount = payload.profile.colorCount ?? state.studio.colorCount;
+  state.studio.noiseCleanupMode =
+    payload.profile.noiseCleanupMode === "light" ||
+    payload.profile.noiseCleanupMode === "standard" ||
+    payload.profile.noiseCleanupMode === "strong"
+      ? payload.profile.noiseCleanupMode
+      : "off";
   state.studio.removeBackground = payload.profile.removeBackground === true;
 
   els.commandsOutput.value = payload.commands.join("\n");
@@ -1035,8 +1054,11 @@ function applyGeneratedStudioPayload(payload) {
     els.statColors.textContent = `${payload.stats.usedColorIndexes.length} / ${state.studio.colorCount} 自动量化色`;
   }
   els.statPixels.textContent = String(payload.stats.totalPixels);
+  const cleanupChangedCells = payload.stats.noiseCleanup?.changedCellCount ?? 0;
   els.statCommands.textContent = payload.stats.pathStats
-    ? `${payload.stats.commandCount} · L ${payload.stats.pathStats.lineRunCount}`
+    ? `${payload.stats.commandCount} · L ${payload.stats.pathStats.lineRunCount}${
+        cleanupChangedCells > 0 ? ` · Δ ${cleanupChangedCells}` : ""
+      }`
     : String(payload.stats.commandCount);
   els.statRuntime.textContent = payload.stats.estimatedRuntimeLabel;
   void updatePreviewBounds(payload);
@@ -1218,6 +1240,7 @@ async function executeStudioCommands({ logPrefix }) {
           imageScalePercent: state.studio.imageScalePercent,
           imageOffsetXPercent: state.studio.imageOffsetXPercent,
           imageOffsetYPercent: state.studio.imageOffsetYPercent,
+          noiseCleanupMode: state.studio.noiseCleanupMode,
         },
         portPath: state.selectedPortPath,
         baudRate: state.studio.profile.baudRate,
@@ -1988,6 +2011,7 @@ function setStudioBusy(isBusy) {
   els.offsetYRange.disabled = isBusy;
   els.sizeSelect.disabled = isBusy;
   els.brushSizeSelect.disabled = isBusy;
+  els.noiseCleanupSelect.disabled = isBusy;
   els.copyButton.disabled = isBusy || state.commands.length === 0;
   els.downloadButton.disabled = isBusy || state.commands.length === 0;
   syncStudioUi();
@@ -2867,6 +2891,7 @@ function syncStudioUi() {
   els.previewGuideSelect.value = state.studio.previewGuideMode;
   els.previewCanvas.dataset.guide = state.studio.previewGuideMode;
   els.colorModeSelect.value = state.studio.colorMode;
+  els.noiseCleanupSelect.value = state.studio.noiseCleanupMode;
   els.autoRemoveBackgroundCheckbox.checked = state.studio.removeBackground;
   syncStudioColorCountOptions();
   const backgroundHint = state.studio.removeBackground
@@ -2905,6 +2930,7 @@ function syncStudioUi() {
   els.offsetYRange.disabled = state.studio.busy || executionActive;
   els.offsetYInput.disabled = state.studio.busy || executionActive;
   els.colorModeSelect.disabled = state.studio.busy || executionActive;
+  els.noiseCleanupSelect.disabled = state.studio.busy || executionActive;
   els.autoRemoveBackgroundCheckbox.disabled = state.studio.busy || executionActive;
   els.previewGuideSelect.disabled = false;
   els.colorCountSelect.disabled =

--- a/apps/desktop/src/web/static/index.html
+++ b/apps/desktop/src/web/static/index.html
@@ -182,6 +182,16 @@
                   <option value="128">128 色</option>
                 </select>
               </label>
+
+              <label>
+                <span>噪点清理</span>
+                <select id="noise-cleanup-select">
+                  <option value="off" selected>关闭</option>
+                  <option value="light">轻度</option>
+                  <option value="standard">标准</option>
+                  <option value="strong">强力</option>
+                </select>
+              </label>
             </div>
 
             <div class="template-picker-card">

--- a/apps/desktop/test/image-noise-cleanup.test.ts
+++ b/apps/desktop/test/image-noise-cleanup.test.ts
@@ -1,0 +1,261 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+
+import sharp from "sharp";
+
+import { calculatePathStats, generateDrawPlan } from "../src/app/generateDrawPlan.js";
+import {
+  calculatePixelMapNoiseStats,
+  cleanupPixelMapNoise,
+} from "../src/image/noiseCleanup.js";
+import { estimateRuntimeMs, generateScanlinePlan } from "../src/path/scanline.js";
+import type { DrawingProfile, Pixel, PixelMap } from "../src/types.js";
+
+const COLORS = {
+  red: { colorIndex: 0, colorHex: "#cc0000" },
+  blue: { colorIndex: 1, colorHex: "#0000cc" },
+  cyan: { colorIndex: 2, colorHex: "#00ffff" },
+  black: { colorIndex: 3, colorHex: "#000000" },
+};
+
+function makeProfile(overrides: Partial<DrawingProfile> = {}): DrawingProfile {
+  return {
+    profileName: "noise-cleanup-test",
+    baudRate: 115200,
+    canvasWidth: 32,
+    canvasHeight: 32,
+    resizeMode: "contain",
+    cellMoveDuration: 80,
+    inputDelay: 45,
+    homeDuration: 1800,
+    buttonPressDuration: 65,
+    colorChangeDuration: 450,
+    ackTimeoutMs: 2_000,
+    commandRetryCount: 1,
+    drawButton: "A",
+    colorMode: "palette",
+    colorCount: 4,
+    monoThreshold: 128,
+    palette: ["#cc0000", "#0000cc", "#00ffff", "#000000"],
+    brushSize: 1,
+    startCursor: "center",
+    startTool: "pen",
+    startColorIndex: 0,
+    centerToTopLeftDx: 0,
+    centerToTopLeftDy: 0,
+    ...overrides,
+  };
+}
+
+function transparentPixel(x: number, y: number): Pixel {
+  return {
+    x,
+    y,
+    colorIndex: -1,
+    colorHex: "#ffffff",
+    alpha: 0,
+  };
+}
+
+function colorPixel(
+  x: number,
+  y: number,
+  color: { colorIndex: number; colorHex: string },
+): Pixel {
+  return {
+    x,
+    y,
+    colorIndex: color.colorIndex,
+    colorHex: color.colorHex,
+    alpha: 255,
+  };
+}
+
+function makeFilledPixelMap(
+  width: number,
+  height: number,
+  fill: { colorIndex: number; colorHex: string } | null,
+): PixelMap {
+  return Array.from({ length: height }, (_, y) =>
+    Array.from({ length: width }, (_, x) => (fill ? colorPixel(x, y, fill) : transparentPixel(x, y))),
+  );
+}
+
+function setColor(
+  pixelMap: PixelMap,
+  points: Array<{ x: number; y: number }>,
+  color: { colorIndex: number; colorHex: string },
+): void {
+  for (const point of points) {
+    const row = pixelMap[point.y];
+
+    if (!row) {
+      continue;
+    }
+
+    row[point.x] = colorPixel(point.x, point.y, color);
+  }
+}
+
+function makeNoisyFieldPixelMap(width: number, height: number): PixelMap {
+  const pixelMap = makeFilledPixelMap(width, height, COLORS.red);
+  const islands: Array<{ x: number; y: number }> = [];
+
+  for (let y = 2; y < height - 2; y += 3) {
+    for (let x = 2; x < width - 2; x += 4) {
+      islands.push({ x, y });
+    }
+  }
+
+  setColor(pixelMap, islands, COLORS.blue);
+  return pixelMap;
+}
+
+test("off mode is a no-op for the logical pixel map", () => {
+  const pixelMap = makeFilledPixelMap(3, 3, COLORS.red);
+  pixelMap[1]![1] = colorPixel(1, 1, COLORS.blue);
+
+  const result = cleanupPixelMapNoise(pixelMap, { mode: "off" });
+
+  assert.deepEqual(result.pixelMap, pixelMap);
+  assert.equal(result.stats.changedCellCount, 0);
+  assert.equal(result.stats.thresholdCells, 0);
+});
+
+test("tiny island merges into the majority neighboring color", () => {
+  const pixelMap = makeFilledPixelMap(3, 3, COLORS.red);
+  pixelMap[1]![1] = colorPixel(1, 1, COLORS.blue);
+
+  const result = cleanupPixelMapNoise(pixelMap, { mode: "light" });
+
+  assert.equal(result.pixelMap[1]![1]!.colorIndex, COLORS.red.colorIndex);
+  assert.equal(result.stats.changedCellCount, 1);
+});
+
+test("multi-color neighbor tie-break is deterministic and uses RGB distance", () => {
+  const pixelMap = makeFilledPixelMap(5, 5, null);
+  setColor(pixelMap, [
+    { x: 1, y: 0 },
+    { x: 2, y: 0 },
+    { x: 3, y: 0 },
+    { x: 2, y: 1 },
+    { x: 1, y: 4 },
+    { x: 2, y: 4 },
+    { x: 3, y: 4 },
+    { x: 2, y: 3 },
+  ], COLORS.red);
+  setColor(pixelMap, [
+    { x: 0, y: 1 },
+    { x: 0, y: 2 },
+    { x: 0, y: 3 },
+    { x: 1, y: 2 },
+    { x: 4, y: 1 },
+    { x: 4, y: 2 },
+    { x: 4, y: 3 },
+    { x: 3, y: 2 },
+  ], COLORS.cyan);
+  pixelMap[2]![2] = colorPixel(2, 2, COLORS.blue);
+
+  const first = cleanupPixelMapNoise(pixelMap, { mode: "light" });
+  const second = cleanupPixelMapNoise(pixelMap, { mode: "light" });
+
+  assert.equal(first.pixelMap[2]![2]!.colorIndex, COLORS.cyan.colorIndex);
+  assert.equal(first.pixelMap[2]![2]!.colorHex, COLORS.cyan.colorHex);
+  assert.deepEqual(first.pixelMap, second.pixelMap);
+});
+
+test("transparent cells are preserved and isolated drawable islands stay unchanged", () => {
+  const nearTransparent = makeFilledPixelMap(4, 4, null);
+  setColor(nearTransparent, [
+    { x: 2, y: 1 },
+    { x: 3, y: 1 },
+    { x: 2, y: 2 },
+    { x: 3, y: 2 },
+  ], COLORS.red);
+  nearTransparent[1]![1] = colorPixel(1, 1, COLORS.blue);
+
+  const cleaned = cleanupPixelMapNoise(nearTransparent, { mode: "light" });
+
+  assert.equal(cleaned.pixelMap[1]![1]!.colorIndex, COLORS.red.colorIndex);
+  assert.deepEqual(cleaned.pixelMap[0]![0], transparentPixel(0, 0));
+  assert.deepEqual(cleaned.pixelMap[3]![0], transparentPixel(0, 3));
+
+  const isolated = makeFilledPixelMap(3, 3, null);
+  isolated[1]![1] = colorPixel(1, 1, COLORS.blue);
+
+  const isolatedResult = cleanupPixelMapNoise(isolated, { mode: "strong" });
+
+  assert.deepEqual(isolatedResult.pixelMap, isolated);
+  assert.equal(isolatedResult.stats.changedCellCount, 0);
+});
+
+test("components at the active threshold are preserved", () => {
+  const pixelMap = makeFilledPixelMap(4, 4, COLORS.red);
+  setColor(pixelMap, [
+    { x: 1, y: 1 },
+    { x: 2, y: 1 },
+    { x: 1, y: 2 },
+    { x: 2, y: 2 },
+  ], COLORS.blue);
+
+  const result = cleanupPixelMapNoise(pixelMap, { mode: "light" });
+
+  assert.equal(result.stats.thresholdCells, 4);
+  assert.equal(result.stats.changedCellCount, 0);
+  assert.deepEqual(result.pixelMap, pixelMap);
+});
+
+test("standard cleanup materially reduces synthetic noise planner metrics", () => {
+  const profile = makeProfile({ canvasWidth: 40, canvasHeight: 30 });
+  const noisy = makeNoisyFieldPixelMap(40, 30);
+  const cleaned = cleanupPixelMapNoise(noisy, { mode: "standard" });
+  const beforeStats = calculatePixelMapNoiseStats(noisy, cleaned.stats.thresholdCells);
+  const afterStats = calculatePixelMapNoiseStats(cleaned.pixelMap, cleaned.stats.thresholdCells);
+  const beforePlan = generateScanlinePlan(noisy, profile);
+  const afterPlan = generateScanlinePlan(cleaned.pixelMap, profile);
+  const beforePathStats = calculatePathStats(beforePlan.commands);
+  const afterPathStats = calculatePathStats(afterPlan.commands);
+  const beforeRuntime = estimateRuntimeMs(beforePlan.commands, profile);
+  const afterRuntime = estimateRuntimeMs(afterPlan.commands, profile);
+
+  assert.ok(
+    afterStats.connectedComponentCount <= beforeStats.connectedComponentCount * 0.5,
+    `expected components to drop by at least 50%, before=${beforeStats.connectedComponentCount}, after=${afterStats.connectedComponentCount}`,
+  );
+  assert.ok(
+    afterPathStats.lineRunCount < beforePathStats.lineRunCount,
+    `expected line runs to drop, before=${beforePathStats.lineRunCount}, after=${afterPathStats.lineRunCount}`,
+  );
+  assert.ok(
+    afterRuntime < beforeRuntime * 0.8,
+    `expected runtime to improve materially, before=${beforeRuntime}, after=${afterRuntime}`,
+  );
+});
+
+test("explicit off generation matches default generation outputs", async () => {
+  const profile = makeProfile({
+    canvasWidth: 8,
+    canvasHeight: 8,
+    colorMode: "mono",
+    colorCount: 2,
+    palette: ["#000000", "#ffffff"],
+  });
+  const source = await sharp({
+    create: {
+      width: 8,
+      height: 8,
+      channels: 4,
+      background: { r: 0, g: 0, b: 0, alpha: 255 },
+    },
+  })
+    .png()
+    .toBuffer();
+  const defaultPlan = await generateDrawPlan(source, profile, 1);
+  const offPlan = await generateDrawPlan(source, profile, 1, { noiseCleanupMode: "off" });
+
+  assert.deepEqual(offPlan.pixelMap, defaultPlan.pixelMap);
+  assert.deepEqual(offPlan.usedColorIndexes, defaultPlan.usedColorIndexes);
+  assert.equal(offPlan.commands.length, defaultPlan.commands.length);
+  assert.equal(Buffer.compare(offPlan.previewPng, defaultPlan.previewPng), 0);
+  assert.equal(offPlan.noiseCleanupStats.changedCellCount, 0);
+});


### PR DESCRIPTION
## Summary / 摘要

### EN
Adds an optional post-quantization noise cleanup pass for image preprocessing. The cleanup runs on the final logical draw grid after brush collapse, so disabled mode preserves the existing planner input and enabled modes reduce tiny connected color islands before scanline planning.

### CN
新增一个可选的图片预处理噪点清理步骤。清理发生在量化和画笔网格折叠之后，直接作用于最终逻辑绘制网格；关闭时保持现有 planner 输入不变，开启后会在生成 scanline 绘制计划前合并很小的连通颜色孤岛。

## Actions Done / 已完成改动

### EN
- Added `NoiseCleanupMode`: `off`, `light`, `standard`, `strong`; default remains `off`.
- Added `apps/desktop/src/image/noiseCleanup.ts` as a pure cleanup module.
- Detects 4-connected components by `colorIndex` and ignores non-drawable/transparent cells.
- Merges tiny components into neighboring drawable colors by majority border color.
- Added deterministic tie-breaking: neighbor count, RGB distance, lower color index, then hex string.
- Preserves transparent cells and does not merge into transparency.
- Recomputes `usedColorIndexes` after cleanup.
- Wires `noiseCleanupMode` through `pixelizeImage`, `generateDrawPlan`, and `/api/generate`.
- Exposes the option in Studio UI as `噪点清理`, defaulting to `关闭`.
- Adds cleanup stats to the server response under `stats.noiseCleanup`.
- Adds focused automated tests for no-op mode, merge behavior, tie-breaks, transparency, threshold preservation, planner metric improvement, and disabled generation equivalence.

### CN
- 新增 `NoiseCleanupMode`：`off`、`light`、`standard`、`strong`，默认仍为 `off`。
- 新增纯函数模块 `apps/desktop/src/image/noiseCleanup.ts`。
- 按 `colorIndex` 检测 4 连通组件，并忽略透明 / 不可绘制格子。
- 将很小的组件合并到相邻可绘制颜色中，优先选择边界邻居中数量最多的颜色。
- 加入确定性的平局规则：邻居数量、RGB 距离、更小 color index、最后按 hex 字符串。
- 保留透明格子，不会把颜色合并到透明区域。
- 清理后重新计算 `usedColorIndexes`。
- 已贯通 `pixelizeImage`、`generateDrawPlan` 和 `/api/generate`。
- Studio UI 新增 `噪点清理` 选择器，默认 `关闭`。
- 服务端响应新增 `stats.noiseCleanup` 清理统计。
- 新增自动化测试覆盖 no-op、孤岛合并、确定性平局、透明保留、阈值保留、planner 指标改善，以及关闭模式与默认生成结果一致。

## Behavior Notes / 行为说明

### EN
This is not primarily a color-count reducer. It only reduces used colors when a color exists exclusively as tiny removable islands. The main expected wins are fewer connected components, fewer broken line runs, less cursor travel, fewer commands, and lower estimated runtime.

Recommendation from the evidence: keep default `off`; use `light` for noisy/compressed/simple imports; use `standard` or `strong` only when speed matters more than tiny detail preservation.

### CN
这个功能的主要目标不是减少用色数量。只有当某个颜色完全只存在于可清理的小孤岛中时，用色数才会下降。它更主要的收益是减少连通组件、减少断裂线段、降低游标移动、减少命令数量和预计耗时。

基于当前证据，建议保持默认 `off`；噪声较多、压缩痕迹明显、结构简单的图片可尝试 `light`；只有在速度优先且不太在意小细节时再使用 `standard` 或 `strong`。

## Validation / 测试验证

### EN
- `npm ci` was run because the temporary worktree initially had no installed dependencies.
- `npm run check` passed.
- `npm run test:desktop` passed: 53 tests.
- After merging locally into `main`, `npm run check` passed again.
- After merging locally into `main`, `npm run test:desktop` passed again: 53 tests.
- Manual UI smoke: started Studio with `npm run ui:dev` at `http://127.0.0.1:4307`; the new `噪点清理` selector was available for manual preview checks.

### CN
- 临时 worktree 起初没有安装依赖，因此先执行了 `npm ci`。
- `npm run check` 通过。
- `npm run test:desktop` 通过：53 个测试。
- 本地合并到 `main` 后再次执行 `npm run check`，通过。
- 本地合并到 `main` 后再次执行 `npm run test:desktop`，通过：53 个测试。
- 手动 UI smoke：通过 `npm run ui:dev` 启动 Studio，地址为 `http://127.0.0.1:4307`；页面中可见新的 `噪点清理` 选择器，可用于手动预览检查。

## Benchmark Evidence / 基准数据

### EN
Generated ignored benchmark previews and metrics under `tmp/friendmaker-planning/noise-cleanup-benchmark/` during local validation.

Representative numbers:
- Solid field + 1px islands: components `82 -> 1`, commands `390 -> 64`, line runs `111 -> 30`, estimated runtime `191s -> 142s`.
- Clean flat blocks: changed cells `0`, commands stayed `78`, estimated runtime stayed `70s`.
- Transparent background asset: transparent cells stayed `600`, components `21 -> 1`, commands `126 -> 44`.
- Small detail-like marks: cleanup removed 7 intentional tiny marks, which is why default remains `off`.

### CN
本地验证时在 ignored 的 `tmp/friendmaker-planning/noise-cleanup-benchmark/` 下生成了预览图和指标表。

代表数据：
- 纯色底 + 1px 小孤岛：components `82 -> 1`，commands `390 -> 64`，line runs `111 -> 30`，预计耗时 `191s -> 142s`。
- 干净平面色块：changed cells 为 `0`，commands 保持 `78`，预计耗时保持 `70s`。
- 透明背景素材：透明格子保持 `600`，components `21 -> 1`，commands `126 -> 44`。
- 小细节标记：清理会移除 7 个刻意的小标记，因此默认仍保持 `off`。