### PR TITLE
ci: 为 PR 和 main 分支添加类型检查与测试工作流

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,31 @@
+name: CI
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+    branches: [main]
+
+jobs:
+  check:
+    name: Type check & test
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup Node
+        uses: actions/setup-node@v4
+        with:
+          node-version: 24
+          cache: npm
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Type check
+        run: npm run check
+
+      - name: Run tests
+        run: npm run test:desktop


### PR DESCRIPTION
## 概要

- 新增 `.github/workflows/ci.yml`，在每次 PR 和推送到 `main` 时自动运行类型检查（`npm run check`）和测试（`npm run test:desktop`）
- 当前仓库仅在 release 构建时运行类型检查，PR 阶段没有任何自动化验证，类型错误和测试回归可能在合并后才被发现

## 测试计划

- [ ] 确认 CI 在本 PR 上成功运行（类型检查 + 测试全部通过）
- [ ] 确认后续 PR 会自动触发该工作流

🤖 Generated with [Claude Code](https://claude.com/claude-code)