### PR TITLE
fix: improve Switch Bluetooth controller reconnect stability

### DIFF
--- a/apps/desktop/src/serial/sender.ts
+++ b/apps/desktop/src/serial/sender.ts
@@ -197,6 +197,38 @@ function getEmbeddedDeviceLine(line: string): string | null {
   return DEVICE_LINE_PREFIXES.some((prefix) => candidate.startsWith(prefix)) ? candidate : null;
 }
 
+function splitSequencedAckAndEmbeddedDeviceLine(line: string): {
+  ackLine: string;
+  embeddedDeviceLine: string | null;
+} | null {
+  if (!line.startsWith("OK ") && !line.startsWith("ERR ")) {
+    return null;
+  }
+
+  const embeddedIndexes = DEVICE_LINE_PREFIXES.map((prefix) => line.indexOf(prefix)).filter(
+    (index) => index > 0,
+  );
+
+  if (embeddedIndexes.length === 0) {
+    return null;
+  }
+
+  const embeddedIndex = Math.min(...embeddedIndexes);
+  const ackLine = line.slice(0, embeddedIndex).trim();
+
+  if (!parseSequencedAck(ackLine)) {
+    return null;
+  }
+
+  const embeddedDeviceLine = line.slice(embeddedIndex).trim();
+  return {
+    ackLine,
+    embeddedDeviceLine: DEVICE_LINE_PREFIXES.some((prefix) => embeddedDeviceLine.startsWith(prefix))
+      ? embeddedDeviceLine
+      : null,
+  };
+}
+
 export function isCongestedControllerSendReportLine(line: string): boolean {
   const match =
     /^WARN bt hid event=send-report status=(\d+) reason=(\d+) report=(\d+)$/u.exec(line.trim());
@@ -251,9 +283,14 @@ function waitForAck(
         return;
       }
 
-      const ack = parseSequencedAck(line);
+      const splitLine = splitSequencedAckAndEmbeddedDeviceLine(line);
+      const ack = parseSequencedAck(splitLine?.ackLine ?? line);
 
       if (ack) {
+        if (splitLine?.embeddedDeviceLine) {
+          options?.onDeviceLine?.(splitLine.embeddedDeviceLine);
+        }
+
         if (ack.sessionId !== expected.sessionId || ack.sequence !== expected.sequence) {
           options?.onDeviceLine?.(
             `WARN ignored ack session=${ack.sessionId} seq=${ack.sequence} expected=${expected.sessionId}:${expected.sequence}`,

--- a/apps/desktop/src/web/static/app.js
+++ b/apps/desktop/src/web/static/app.js
@@ -1,5 +1,7 @@
 import {
+  asControllerDisconnectedStatus,
   deriveControllerStatus,
+  shouldMarkControllerDisconnected,
   shouldReuseExistingControllerConnection,
 } from "./controllerStatus.js";
 import {
@@ -178,6 +180,7 @@ const state = {
       readyInferredValue: false,
       unstableValue: false,
       reconnectRecommendedValue: false,
+      disconnectedValue: false,
       sendReportFailureCount: 0,
       lastSendReportStatus: null,
       lastSendReportReason: null,
@@ -364,6 +367,7 @@ const STUDIO_RESET_REVEAL_DELAY_MS = 4_000;
 let firmwareFlashPollTimer = null;
 let controllerStatusPollTimer = null;
 let controllerStatusPollDeadlineMs = 0;
+let controllerStatusPollIntervalMs = 0;
 let controllerStatusPollInFlight = false;
 let controllerStatusTimeoutRecoveryAttempted = false;
 let studioPreviewRefreshTimer = null;
@@ -372,6 +376,7 @@ let studioPreviewBoundsRequestSerial = 0;
 const studioTemplateOverlayCache = new Map();
 const CONTROLLER_STATUS_POLL_INTERVAL_MS = 1_000;
 const CONTROLLER_STATUS_POLL_WINDOW_MS = 45_000;
+const CONTROLLER_READY_WATCH_INTERVAL_MS = 3_000;
 
 const STUDIO_IMAGE_SCALE_LIMITS = {
   min: 25,
@@ -1212,6 +1217,7 @@ async function executeStudioCommands({ logPrefix }) {
 
   appendLog(els.studioLogOutput, logPrefix);
 
+  stopControllerStatusPolling();
   setStudioBusy(true);
 
   try {
@@ -1808,7 +1814,7 @@ els.controllerInfoButton.addEventListener("click", async () => {
     detail: "正在重置蓝牙并重新进入可发现状态，请保持 Switch 停在“更改握法/顺序”页面。",
   });
 
-  const payload = await runControllerCommands(["BT RESET", "I"], "连接手柄");
+  const payload = await runControllerCommands(["BT RESET LAST-PEER", "I"], "连接手柄");
 
   if (payload) {
     startControllerStatusPolling();
@@ -1823,7 +1829,7 @@ els.controllerResetButton.addEventListener("click", async () => {
     detail: "正在重启蓝牙协议栈并读取最新状态，请稍等片刻。",
   });
 
-  const payload = await runControllerCommands(["BT RESET", "I"], "重置手柄蓝牙");
+  const payload = await runControllerCommands(["BT RESET LAST-PEER", "I"], "重置手柄蓝牙");
 
   if (payload) {
     startControllerStatusPolling();
@@ -1863,6 +1869,11 @@ els.controllerActionButtons.forEach((button) => {
 
     if (commands.length === 0) {
       appendLog(els.controllerLogOutput, `未知测试动作：${action}`);
+      return;
+    }
+
+    stopControllerStatusPolling();
+    if (!(await ensureFreshControllerActionStatus(action))) {
       return;
     }
 
@@ -2448,6 +2459,7 @@ function setControllerPendingStatus({ title, detail }) {
     readyInferredValue: false,
     unstableValue: false,
     reconnectRecommendedValue: false,
+    disconnectedValue: false,
     sendReportFailureCount: 0,
     lastSendReportStatus: null,
     lastSendReportReason: null,
@@ -2464,7 +2476,12 @@ function updateControllerStatusFromLines(lines) {
   if (!status) {
     return;
   }
-  setControllerStatus(status);
+
+  const previousStatus = state.controller.status;
+  const nextStatus = shouldMarkControllerDisconnected(previousStatus, status)
+    ? asControllerDisconnectedStatus(status)
+    : status;
+  setControllerStatus(nextStatus);
 }
 
 function isControllerReadyForStudio() {
@@ -2480,45 +2497,67 @@ function setControllerRecoveryFailedStatus(detail) {
   });
 }
 
-function isControllerConnectionStillInProgress(status = state.controller.status) {
+function shouldAutoRecoverControllerTimeout(status = state.controller.status) {
   return (
     status?.readyValue !== true &&
     status?.tone !== "error" &&
-    (status?.connectedValue === true ||
-      status?.authValue === true ||
-      status?.discoverableValue === true)
+    status?.discoverableValue === true &&
+    status?.authValue !== true &&
+    status?.connectedValue !== true
   );
+}
+
+function canSendControllerAction(action, status = state.controller.status) {
+  if (action === "pair-lr") {
+    return (
+      status?.readyValue === true ||
+      status?.connectedValue === true ||
+      status?.authValue === true
+    );
+  }
+
+  return status?.readyValue === true;
+}
+
+async function ensureFreshControllerActionStatus(action) {
+  const statusOk = await requestControllerStatus({ logErrors: true });
+
+  if (statusOk !== true) {
+    appendLog(els.controllerLogOutput, "动作发送前状态刷新失败，请重新点击“连接手柄”后再试。");
+    return false;
+  }
+
+  if (canSendControllerAction(action)) {
+    return true;
+  }
+
+  if (action === "pair-lr") {
+    appendLog(
+      els.controllerLogOutput,
+      "当前还没有进入可发送输入的蓝牙阶段。请让 Switch 停在“更改握法/顺序”页面继续等待；状态至少到“已认证”或“已连接”后再按 L+R。",
+    );
+  } else {
+    appendLog(
+      els.controllerLogOutput,
+      "当前手柄状态不是“已就绪”，已阻止发送普通按键，避免网页绿色状态过期后继续发无效命令。请重新连接手柄。",
+    );
+  }
+
+  return false;
 }
 
 async function handleControllerStatusPollTimeout() {
   stopControllerStatusPolling();
 
-  if (
-    isControllerConnectionStillInProgress() &&
-    !controllerStatusTimeoutRecoveryAttempted
-  ) {
+  if (shouldAutoRecoverControllerTimeout() && !controllerStatusTimeoutRecoveryAttempted) {
     controllerStatusTimeoutRecoveryAttempted = true;
     appendLog(
       els.controllerLogOutput,
-      "等待连接超过 45 秒，自动重置蓝牙并重试一次。",
+      "等待连接超过 45 秒。为避免打断 Switch 正在进行的蓝牙握手，当前不会自动重置蓝牙；请确认停在“更改握法/顺序”页面后手动点击“重置手柄蓝牙”。",
     );
-    setControllerPendingStatus({
-      title: "正在自动恢复手柄连接",
-      detail: "开发板长时间停留在广播或握手状态，正在重置蓝牙并重新进入可发现状态。",
-    });
-
-    const payload = await runControllerCommands(
-      ["BT RESET LAST-PEER", "I"],
-      "自动恢复手柄连接",
+    setControllerRecoveryFailedStatus(
+      "开发板长时间停留在广播或握手状态。请确认 Switch 停在“更改握法/顺序”页面，然后手动点击“重置手柄蓝牙”；如果还是卡住，再按一下开发板上的 EN 键后重试。",
     );
-
-    if (payload) {
-      startControllerStatusPolling();
-    } else {
-      setControllerRecoveryFailedStatus(
-        "自动恢复没有完成。请重新点击“连接手柄”；如果你是在换一台 Switch 配对，当前不会再默认回连旧主机。",
-      );
-    }
     return;
   }
 
@@ -2609,49 +2648,54 @@ async function pollControllerStatus() {
     return;
   }
 
-  if (state.controller.status.reconnectRecommendedValue === true) {
+  if (state.controller.status.disconnectedValue === true) {
     stopControllerStatusPolling();
-
-    if (!state.controller.autoReconnectAttempted) {
-      state.controller.autoReconnectAttempted = true;
-      appendLog(
-        els.controllerLogOutput,
-        "检测到手柄已经连上但报告通道持续拥塞，自动重置蓝牙并重试一次。",
-      );
-      setControllerPendingStatus({
-        title: "正在自动恢复手柄连接",
-        detail: "检测到当前连接容易立刻断联，正在重置蓝牙并重新进入可发现状态。",
-      });
-
-      const payload = await runControllerCommands(
-        ["BT RESET LAST-PEER", "I"],
-        "自动恢复手柄连接",
-      );
-
-      if (payload) {
-        startControllerStatusPolling();
-      } else {
-        setControllerRecoveryFailedStatus(
-          "自动恢复没有完成。请重新点击“连接手柄”；如果还是容易断联，再按一下开发板上的 EN 键后重试。",
-        );
-      }
-
-      return;
-    }
-
     appendLog(
       els.controllerLogOutput,
-      "自动重试后连接仍然不稳定。请重新点击“连接手柄”；如果还是容易断联，再按一下开发板上的 EN 键后重试。",
+      "检测到蓝牙手柄已断开。通常直接点击网页端“连接手柄”即可恢复；如果长时间无法恢复或一直广播，再进入 Switch 的“更改握法/顺序”页面后重试。",
+    );
+    return;
+  }
+
+  if (state.controller.status.reconnectRecommendedValue === true) {
+    stopControllerStatusPolling();
+    state.controller.autoReconnectAttempted = true;
+    appendLog(
+      els.controllerLogOutput,
+      "检测到手柄报告通道不稳定。为避免打断 Switch 正在进行的蓝牙握手，当前不会自动重置蓝牙；请手动点击“重置手柄蓝牙”后重试。",
+    );
+    setControllerRecoveryFailedStatus(
+      "当前蓝牙报告通道不稳定，继续发送按键容易出现电脑显示完成但 Switch 不响应。请手动重置蓝牙并重新进入“更改握法/顺序”页面配对。",
     );
     return;
   }
 
   if (
-    state.controller.status.readyValue === true ||
     state.controller.status.tone === "error"
   ) {
     stopControllerStatusPolling();
+    return;
   }
+
+  if (state.controller.status.readyValue === true) {
+    controllerStatusPollDeadlineMs = 0;
+    ensureControllerStatusPollTimer(CONTROLLER_READY_WATCH_INTERVAL_MS);
+  }
+}
+
+function ensureControllerStatusPollTimer(intervalMs) {
+  if (controllerStatusPollTimer && controllerStatusPollIntervalMs === intervalMs) {
+    return;
+  }
+
+  if (controllerStatusPollTimer) {
+    window.clearInterval(controllerStatusPollTimer);
+  }
+
+  controllerStatusPollIntervalMs = intervalMs;
+  controllerStatusPollTimer = window.setInterval(() => {
+    void pollControllerStatus();
+  }, intervalMs);
 }
 
 function startControllerStatusPolling(durationMs = CONTROLLER_STATUS_POLL_WINDOW_MS) {
@@ -2664,11 +2708,7 @@ function startControllerStatusPolling(durationMs = CONTROLLER_STATUS_POLL_WINDOW
     Date.now() + durationMs,
   );
 
-  if (!controllerStatusPollTimer) {
-    controllerStatusPollTimer = window.setInterval(() => {
-      void pollControllerStatus();
-    }, CONTROLLER_STATUS_POLL_INTERVAL_MS);
-  }
+  ensureControllerStatusPollTimer(CONTROLLER_STATUS_POLL_INTERVAL_MS);
 
   void pollControllerStatus();
 }
@@ -2682,10 +2722,12 @@ function stopControllerStatusPolling() {
 
   window.clearInterval(controllerStatusPollTimer);
   controllerStatusPollTimer = null;
+  controllerStatusPollIntervalMs = 0;
 }
 
 function renderStudioConnectionStatus() {
   const ready = state.controller.status.readyValue === true;
+  const disconnected = state.controller.status.disconnectedValue === true;
   const connected = state.controller.status.connectedValue === true;
   const auth = state.controller.status.authValue === true;
   const discoverable = state.controller.status.discoverableValue === true;
@@ -2700,6 +2742,11 @@ function renderStudioConnectionStatus() {
     pill = "已连接";
     title = "手柄已连接，可以开始绘制";
     detail = `当前开发板已经处于可发送状态，可以把绘制脚本发到 ${state.selectedPortPath || "串口设备"}。`;
+  } else if (disconnected) {
+    tone = "warning";
+    pill = "已断开";
+    title = "手柄已断开";
+    detail = "Switch 已经不再保持开发板蓝牙手柄连接。通常直接到“手柄测试”页点击“连接手柄”即可恢复；如果长时间无法恢复或一直广播，再进入 Switch 的“更改握法/顺序”页面后重试。";
   } else {
     tone = "warning";
     pill = "需要测试";
@@ -3193,6 +3240,11 @@ function syncTimingLabUi() {
 function syncControllerUi() {
   const hasPort = Boolean(state.selectedPortPath);
   const ready = state.controller.status.readyValue === true;
+  const canAttemptPair =
+    !state.controller.busy &&
+    !state.serialSession.busy &&
+    hasPort &&
+    canSendControllerAction("pair-lr");
   const canSendTestCommands = !state.controller.busy && !state.serialSession.busy && hasPort && ready;
 
   els.controllerPortSelect.disabled = state.controller.busy || state.serialSession.busy;
@@ -3204,7 +3256,8 @@ function syncControllerUi() {
   els.controllerCustomCommands.disabled = !canSendTestCommands;
   els.controllerDisconnectButton.disabled = state.controller.busy || !state.serialSession.connected;
   els.controllerActionButtons.forEach((button) => {
-    button.disabled = !canSendTestCommands;
+    const action = button.dataset.controllerAction ?? "";
+    button.disabled = action === "pair-lr" ? !canAttemptPair : !canSendTestCommands;
   });
   els.controllerTimingHint.textContent = `当前动作测试会先套用 ${buildSharedTimingConfigCommand()}。`;
   renderSerialSessionStatus();
@@ -3310,6 +3363,7 @@ async function runTimedSerialCommands({
 }
 
 async function runControllerCommands(commands, label) {
+  const shouldRefreshStatusAfterRun = !commands.some((command) => command.trim() === "I");
   const result = await runTimedSerialCommands({
     commands,
     label,
@@ -3321,6 +3375,10 @@ async function runControllerCommands(commands, label) {
 
   if (payload?.lines) {
     updateControllerStatusFromLines(payload.lines);
+  }
+
+  if (shouldRefreshStatusAfterRun) {
+    await requestControllerStatus();
   }
 
   return payload;

--- a/apps/desktop/src/web/static/controllerStatus.d.ts
+++ b/apps/desktop/src/web/static/controllerStatus.d.ts
@@ -19,6 +19,7 @@ export interface DerivedControllerStatus {
   readyInferredValue: boolean;
   unstableValue: boolean;
   reconnectRecommendedValue: boolean;
+  disconnectedValue: boolean;
   sendReportFailureCount: number;
   lastSendReportStatus: number | null;
   lastSendReportReason: number | null;
@@ -43,9 +44,23 @@ export function shouldReuseExistingControllerConnection(status: {
   connectedValue?: boolean | null;
   authValue?: boolean | null;
   discoverableValue?: boolean | null;
+  disconnectedValue?: boolean | null;
   reconnectRecommendedValue?: boolean | null;
   unstableValue?: boolean | null;
 } | null | undefined): boolean;
+export function shouldMarkControllerDisconnected(
+  previousStatus: {
+    readyValue?: boolean | null;
+  } | null | undefined,
+  nextStatus: {
+    transport?: string | null;
+    profile?: string | null;
+    readyValue?: boolean | null;
+    connectedValue?: boolean | null;
+    authValue?: boolean | null;
+  } | null | undefined,
+): boolean;
+export function asControllerDisconnectedStatus(status: DerivedControllerStatus): DerivedControllerStatus;
 export function deriveControllerStatus(
   lines: Array<string | null | undefined>,
 ): DerivedControllerStatus | null;

--- a/apps/desktop/src/web/static/controllerStatus.js
+++ b/apps/desktop/src/web/static/controllerStatus.js
@@ -32,7 +32,8 @@ function splitEmbeddedDeviceLine(line) {
 }
 
 function hasControllerInitError(value) {
-  return value !== "-" && value !== "none" && value !== "ESP_OK";
+  const normalized = String(value ?? "").trim();
+  return normalized !== "" && normalized !== "-" && normalized !== "none" && normalized !== "ESP_OK";
 }
 
 function numberFromInfo(value) {
@@ -96,7 +97,11 @@ export function isControllerSendableStatus({ connected, paired, ready }) {
 }
 
 export function shouldReuseExistingControllerConnection(status) {
-  if (status?.reconnectRecommendedValue === true || status?.unstableValue === true) {
+  if (
+    status?.disconnectedValue === true ||
+    status?.reconnectRecommendedValue === true ||
+    status?.unstableValue === true
+  ) {
     return false;
   }
 
@@ -107,11 +112,85 @@ export function shouldReuseExistingControllerConnection(status) {
   );
 }
 
+export function shouldMarkControllerDisconnected(previousStatus, nextStatus) {
+  const nextTransport = String(nextStatus?.transport ?? "");
+  const nextProfile = String(nextStatus?.profile ?? "");
+  const isUsbHidSwitch = nextTransport === "usb-hid-switch" || nextProfile === "switch-hid";
+
+  return (
+    previousStatus?.readyValue === true &&
+    !isUsbHidSwitch &&
+    nextStatus?.readyValue !== true &&
+    nextStatus?.connectedValue !== true &&
+    nextStatus?.authValue !== true
+  );
+}
+
+export function asControllerDisconnectedStatus(status) {
+  return {
+    ...status,
+    tone: "warning",
+    pill: "已断开",
+    title: "手柄已断开",
+    detail:
+      "检测到 Switch 已经不再保持这块开发板的蓝牙手柄连接。常见原因是你直接操作了 Switch Lite 原生手柄，Switch 会切回原生输入并断开这个蓝牙手柄。通常直接点击网页端“连接手柄”即可恢复；如果长时间无法恢复或一直停在广播中，再进入 Switch 的“更改握法/顺序”页面后重试。",
+    ready: "未就绪",
+    readyValue: false,
+    rawReadyValue: false,
+    readyInferredValue: false,
+    unstableValue: false,
+    reconnectRecommendedValue: false,
+    disconnectedValue: true,
+  };
+}
+
 export function deriveControllerStatus(lines) {
   const info = readInfoLineMap(lines);
 
   if (!info.transport && !info.bt_mode && !info.bt_profile) {
     return null;
+  }
+
+  const isUsbHidSwitch = info.transport === "usb-hid-switch" || info.usb_mode === "switch-hid";
+  if (isUsbHidSwitch) {
+    const usbStarted = boolFromInfo(info.usb_started);
+    const usbReportFailures = numberFromInfo(info.usb_report_failures) ?? 0;
+    const usbReports = numberFromInfo(info.usb_reports) ?? 0;
+    const ready = usbStarted === true;
+
+    return {
+      tone: ready ? "success" : "warning",
+      pill: ready ? "USB就绪" : "USB未就绪",
+      title: ready ? "USB有线手柄已启动" : "USB有线手柄还未启动",
+      detail: ready
+        ? "开发板已经启用 USB HID 手柄输出。请确认 Switch Lite 仍通过 OTG 接在开发板原生 USB 口上，然后可以继续发送按键和方向命令。"
+        : "开发板还没有成功启动 USB HID 手柄输出。请检查固件环境、右侧原生 USB 口和 Switch Lite OTG 连接。",
+      transport: info.transport ?? "usb-hid-switch",
+      profile: info.usb_mode ?? "switch-hid",
+      discoverable: "不适用",
+      auth: "不适用",
+      connected: ready ? "USB已启动" : "USB未启动",
+      paired: "不适用",
+      ready: ready ? "可发送" : "未就绪",
+      discoverableValue: null,
+      authValue: null,
+      connectedValue: ready,
+      pairedValue: ready,
+      readyValue: ready,
+      peer: "-",
+      initStep: "-",
+      initError: "-",
+      rawReadyValue: ready,
+      readyInferredValue: false,
+      unstableValue: false,
+      reconnectRecommendedValue: false,
+      disconnectedValue: false,
+      sendReportFailureCount: usbReportFailures,
+      lastSendReportStatus: null,
+      lastSendReportReason: null,
+      lastAclDisconnectReason: null,
+      lastDropReason: usbReports > 0 && usbReportFailures > 0 ? "usb_report_failed" : "-",
+    };
   }
 
   const discoverable = boolFromInfo(info.bt_discoverable);
@@ -135,7 +214,11 @@ export function deriveControllerStatus(lines) {
     sendReportFailureCount >= 10;
   const readyInferredFromPairing = rawReady !== true && connected === true && paired === true && !unstableInferredReady;
   const ready = rawReady === true || readyInferredFromPairing;
-  const initError = info.bt_init_error ?? "-";
+  const initError = String(info.bt_init_error ?? "-").trim() || "-";
+  const discoverableInferredFromInit =
+    discoverable !== false &&
+    info.bt_init_step === "discoverable" &&
+    !hasControllerInitError(initError);
 
   let tone = "idle";
   let pill = "待连接";
@@ -165,7 +248,7 @@ export function deriveControllerStatus(lines) {
     pill = "已认证";
     title = "认证已通过";
     detail = "Switch 已完成蓝牙认证，正在尝试把这块板子接成可用手柄。";
-  } else if (discoverable === true) {
+  } else if (discoverable === true || discoverableInferredFromInit) {
     tone = "running";
     pill = "广播中";
     title = "等待 Switch 发现";
@@ -189,7 +272,7 @@ export function deriveControllerStatus(lines) {
     connected: boolLabel(connected, ["已连接", "未连接"]),
     paired: boolLabel(paired, ["已配对", "未配对"]),
     ready: boolLabel(ready, ["可发送", "未就绪"]),
-    discoverableValue: discoverable,
+    discoverableValue: discoverable === true || discoverableInferredFromInit,
     authValue: authComplete,
     connectedValue: connected,
     pairedValue: paired,
@@ -201,6 +284,7 @@ export function deriveControllerStatus(lines) {
     readyInferredValue: readyInferredFromPairing,
     unstableValue: unstableInferredReady,
     reconnectRecommendedValue: unstableInferredReady,
+    disconnectedValue: false,
     sendReportFailureCount,
     lastSendReportStatus,
     lastSendReportReason,

--- a/apps/desktop/test/controller-status.test.ts
+++ b/apps/desktop/test/controller-status.test.ts
@@ -3,9 +3,11 @@ import { readFile } from "node:fs/promises";
 import test from "node:test";
 
 import {
+  asControllerDisconnectedStatus,
   deriveControllerStatus,
   normalizeControllerDeviceLines,
   readInfoLineMap,
+  shouldMarkControllerDisconnected,
   shouldReuseExistingControllerConnection,
 } from "../src/web/static/controllerStatus.js";
 
@@ -91,6 +93,28 @@ test("deriveControllerStatus marks congested inferred-ready links as unstable", 
   assert.equal(status?.lastAclDisconnectReason, 19);
 });
 
+test("deriveControllerStatus treats USB HID transport as sendable when USB is started", () => {
+  const status = deriveControllerStatus([
+    "INFO transport=usb-hid-switch",
+    "INFO usb_mode=switch-hid",
+    "INFO usb_started=true",
+    "INFO usb_reports=1",
+    "INFO usb_report_failures=1",
+  ]);
+
+  assert.ok(status);
+  assert.equal(status?.tone, "success");
+  assert.equal(status?.transport, "usb-hid-switch");
+  assert.equal(status?.profile, "switch-hid");
+  assert.equal(status?.connected, "USB已启动");
+  assert.equal(status?.paired, "不适用");
+  assert.equal(status?.ready, "可发送");
+  assert.equal(status?.connectedValue, true);
+  assert.equal(status?.pairedValue, true);
+  assert.equal(status?.readyValue, true);
+  assert.equal(status?.sendReportFailureCount, 1);
+});
+
 test("shouldReuseExistingControllerConnection keeps active bluetooth sessions intact", () => {
   assert.equal(
     shouldReuseExistingControllerConnection({
@@ -148,6 +172,53 @@ test("shouldReuseExistingControllerConnection keeps active bluetooth sessions in
     }),
     false,
   );
+  assert.equal(
+    shouldReuseExistingControllerConnection({
+      readyValue: false,
+      connectedValue: false,
+      authValue: false,
+      discoverableValue: false,
+      disconnectedValue: true,
+    }),
+    false,
+  );
+});
+
+test("controller status marks a previously ready bluetooth controller as disconnected", () => {
+  const nextStatus = deriveControllerStatus([
+    "INFO transport=classic-bt-uartswitchcon",
+    "INFO bt_profile=uartswitchcon-pro-controller",
+    "INFO bt_discoverable=false",
+    "INFO bt_auth_complete=false",
+    "INFO bt_connected=false",
+    "INFO bt_paired=false",
+    "INFO bt_ready_for_reports=false",
+    "INFO bt_last_peer=E0:EF:BF:10:40:25",
+    "INFO bt_last_acl_disconnect_reason=19",
+    "INFO bt_init_step=discoverable",
+    "INFO bt_init_error=ESP_OK",
+  ]);
+
+  assert.ok(nextStatus);
+  assert.equal(
+    shouldMarkControllerDisconnected(
+      {
+        readyValue: true,
+      },
+      nextStatus,
+    ),
+    true,
+  );
+
+  const disconnectedStatus = asControllerDisconnectedStatus(nextStatus);
+  assert.equal(disconnectedStatus.tone, "warning");
+  assert.equal(disconnectedStatus.pill, "已断开");
+  assert.equal(disconnectedStatus.title, "手柄已断开");
+  assert.equal(disconnectedStatus.ready, "未就绪");
+  assert.equal(disconnectedStatus.readyValue, false);
+  assert.equal(disconnectedStatus.disconnectedValue, true);
+  assert.match(disconnectedStatus.detail, /直接点击网页端“连接手柄”即可恢复/u);
+  assert.match(disconnectedStatus.detail, /更改握法\/顺序/u);
 });
 
 test("controller status updates also resync the controller action buttons", async () => {
@@ -163,12 +234,12 @@ test("controller status updates also resync the controller action buttons", asyn
 
   assert.match(
     appSource,
-    /els\.controllerInfoButton\.addEventListener\("click", async \(\) => \{[\s\S]*await requestControllerStatus\(\)[\s\S]*shouldReuseExistingControllerConnection\(state\.controller\.status\)[\s\S]*runControllerCommands\(\["BT RESET", "I"\], "连接手柄"\)/u,
+    /els\.controllerInfoButton\.addEventListener\("click", async \(\) => \{[\s\S]*await requestControllerStatus\(\)[\s\S]*shouldReuseExistingControllerConnection\(state\.controller\.status\)[\s\S]*runControllerCommands\(\["BT RESET LAST-PEER", "I"\], "连接手柄"\)/u,
   );
 
   assert.match(
     appSource,
-    /state\.controller\.status\.reconnectRecommendedValue === true[\s\S]*BT RESET LAST-PEER[\s\S]*自动恢复手柄连接/u,
+    /state\.controller\.status\.reconnectRecommendedValue === true[\s\S]*当前不会自动重置蓝牙[\s\S]*setControllerRecoveryFailedStatus\(/u,
   );
 
   assert.match(
@@ -178,11 +249,36 @@ test("controller status updates also resync the controller action buttons", asyn
 
   assert.match(
     appSource,
-    /controllerStatusTimeoutRecoveryAttempted = true[\s\S]*等待连接超过 45 秒，自动重置蓝牙并重试一次。[\s\S]*BT RESET LAST-PEER[\s\S]*自动恢复手柄连接/u,
+    /controllerStatusTimeoutRecoveryAttempted = true[\s\S]*等待连接超过 45 秒[\s\S]*当前不会自动重置蓝牙[\s\S]*setControllerRecoveryFailedStatus\(/u,
   );
 
   assert.match(
     appSource,
-    /if \(payload\) \{[\s\S]*startControllerStatusPolling\(\);[\s\S]*\} else \{[\s\S]*setControllerRecoveryFailedStatus\(/u,
+    /shouldMarkControllerDisconnected\(previousStatus, status\)[\s\S]*asControllerDisconnectedStatus\(status\)/u,
+  );
+
+  assert.match(
+    appSource,
+    /state\.controller\.status\.disconnectedValue === true[\s\S]*检测到蓝牙手柄已断开[\s\S]*stopControllerStatusPolling\(\)/u,
+  );
+
+  assert.match(
+    appSource,
+    /state\.controller\.status\.readyValue === true[\s\S]*controllerStatusPollDeadlineMs = 0[\s\S]*ensureControllerStatusPollTimer\(CONTROLLER_READY_WATCH_INTERVAL_MS\)/u,
+  );
+
+  assert.match(
+    appSource,
+    /async function executeStudioCommands[\s\S]*appendLog\(els\.studioLogOutput, logPrefix\);[\s\S]*stopControllerStatusPolling\(\);[\s\S]*setStudioBusy\(true\);/u,
+  );
+
+  assert.match(
+    appSource,
+    /ensureFreshControllerActionStatus\(action\)[\s\S]*runControllerCommands\(commands, `测试动作 \$\{action\}`\)/u,
+  );
+
+  assert.match(
+    appSource,
+    /const shouldRefreshStatusAfterRun = !commands\.some\(\(command\) => command\.trim\(\) === "I"\)[\s\S]*await requestControllerStatus\(\);/u,
   );
 });

--- a/apps/desktop/test/firmware-flash.test.ts
+++ b/apps/desktop/test/firmware-flash.test.ts
@@ -111,7 +111,7 @@ test("controller firmware keeps bluetooth identity stable and waits for host HID
   );
   assert.match(
     firmwareSource,
-    /reconnectLastPeerOnRegister_ && hasPeerAddress_[\s\S]*attemptVirtualCablePlug\(lastPeerAddress_, "register-app-last-peer"\)/u,
+    /reconnectLastPeerOnRegister_ && hasPeerAddress_[\s\S]*scheduleLastPeerReconnect\("register-app-last-peer"\)/u,
   );
   assert.doesNotMatch(
     firmwareSource,

--- a/firmware/esp32/src/classic_bt_controller_transport.cpp
+++ b/firmware/esp32/src/classic_bt_controller_transport.cpp
@@ -29,12 +29,13 @@ constexpr uint8_t kStickMax = 255;
 // is congested, so a short retry window is safe and avoids aborting the whole
 // draw on a transient queue backup.
 constexpr uint8_t kHidErrCongested = 8;
-constexpr uint16_t kHidCongestionRetryDelayMs = HID_REPEAT_INTERVAL_MS;
-constexpr uint16_t kHidCongestionRetryBudgetMs = HID_REPEAT_INTERVAL_MS * 4;
+constexpr uint16_t kHidCongestionRetryDelayMs = HID_REPEAT_INTERVAL_MS * 2;
+constexpr uint16_t kHidCongestionRetryBudgetMs = 800;
 constexpr uint16_t kIdleDisconnectedReportIntervalMs = 100;
-constexpr uint16_t kIdlePrePairingReportIntervalMs = 30;
-constexpr uint16_t kIdleCongestedReportIntervalMs = 45;
-constexpr uint16_t kIdleConnectedReportIntervalMs = 15;
+constexpr uint16_t kIdlePrePairingReportIntervalMs = 60;
+constexpr uint16_t kIdleCongestedReportIntervalMs = 120;
+constexpr uint16_t kIdleConnectedReportIntervalMs = 30;
+constexpr uint16_t kLastPeerReconnectDelayMs = 1200;
 
 uint8_t kHidDescriptor[] = {
     0x05, 0x01, 0x09, 0x05, 0xa1, 0x01, 0x06, 0x01, 0xff, 0x85, 0x21, 0x09,
@@ -115,6 +116,11 @@ uint8_t kReply02[] = {
     0xF0, 0xD7, 0x01, 0x02, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
     0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
     0x00, 0x00};
+constexpr size_t kReply02BluetoothAddressOffset = 18;
+
+void setReply02BluetoothAddress(const uint8_t address[6]) {
+  std::memcpy(&kReply02[kReply02BluetoothAddressOffset], address, 6);
+}
 
 uint8_t kReply08[] = {
     0x01, 0x8E, 0x00, 0x00, 0x00, 0x00, 0x08, 0x80, 0x00, 0x00, 0x00, 0x00,
@@ -251,9 +257,11 @@ bool ClassicBtControllerTransport::initializeNvsAndBaseAddress() {
   uint8_t baseMac[6] = {};
   const char *baseMacSource = "efuse-derived";
   bool shouldPersistDerivedMac = false;
-  nvs_handle handle;
+  bool nvsOpened = false;
+  nvs_handle handle = 0;
   err = nvs_open("storage", NVS_READWRITE, &handle);
   if (err == ESP_OK) {
+    nvsOpened = true;
     size_t size = sizeof(baseMac);
     err = nvs_get_blob(handle, "mac_addr", baseMac, &size);
     if (err == ESP_OK && size == sizeof(baseMac)) {
@@ -286,7 +294,18 @@ bool ClassicBtControllerTransport::initializeNvsAndBaseAddress() {
     }
   }
 
-  if (err == ESP_OK || shouldPersistDerivedMac) {
+  if (nvsOpened) {
+    uint8_t peerAddress[6] = {};
+    size_t peerAddressSize = sizeof(peerAddress);
+    const esp_err_t peerErr = nvs_get_blob(handle, "peer_addr", peerAddress, &peerAddressSize);
+    if (peerErr == ESP_OK && peerAddressSize == sizeof(peerAddress)) {
+      std::memcpy(lastPeerAddress_, peerAddress, sizeof(lastPeerAddress_));
+      hasPeerAddress_ = true;
+      reconnectLastPeerOnRegister_ = true;
+      Serial.printf(
+          "INFO bt loaded_peer=%s source=nvs\n",
+          formatBluetoothAddress(lastPeerAddress_).c_str());
+    }
     nvs_close(handle);
   }
 
@@ -294,6 +313,10 @@ bool ClassicBtControllerTransport::initializeNvsAndBaseAddress() {
   if (err != ESP_OK) {
     Serial.printf("WARN base_mac_set failed err=%s\n", esp_err_to_name(err));
     return false;
+  }
+  uint8_t btMac[6] = {};
+  if (esp_read_mac(btMac, ESP_MAC_BT) == ESP_OK) {
+    setReply02BluetoothAddress(btMac);
   }
 
   Serial.printf(
@@ -305,6 +328,17 @@ bool ClassicBtControllerTransport::initializeNvsAndBaseAddress() {
       baseMac[4],
       baseMac[5],
       baseMacSource);
+  if (btMac[0] != 0 || btMac[1] != 0 || btMac[2] != 0 || btMac[3] != 0 ||
+      btMac[4] != 0 || btMac[5] != 0) {
+    Serial.printf(
+        "INFO bt device_mac=%02X:%02X:%02X:%02X:%02X:%02X\n",
+        btMac[0],
+        btMac[1],
+        btMac[2],
+        btMac[3],
+        btMac[4],
+        btMac[5]);
+  }
   return true;
 }
 
@@ -420,6 +454,14 @@ void ClassicBtControllerTransport::clearConnectionState() {
   initStep_ = "idle";
   initError_ = "none";
   ignoredReportCount_ = 0;
+  intrReportCount_ = 0;
+  lastIntrReportId_ = 0;
+  lastIntrReportLen_ = 0;
+  lastIntrSubcommand_ = 0;
+  lastIntrArg0_ = 0;
+  lastIntrArg1_ = 0;
+  replyCount_ = 0;
+  lastReplyLabel_ = "-";
   lastIgnoredReportId_ = 0;
   lastIgnoredReportLen_ = 0;
   lastAclDisconnectReason_ = 0;
@@ -430,13 +472,17 @@ void ClassicBtControllerTransport::clearConnectionState() {
   lastSendReportId_ = 0;
   sendReportFailureCount_ = 0;
   lastDropReason_ = "none";
-  reconnectLastPeerOnRegister_ = false;
+  reconnectLastPeerOnRegister_ = hasPeerAddress_;
 }
 
 bool ClassicBtControllerTransport::shutdownClassicBluetooth() {
   initStep_ = "shutdown";
   initError_ = "none";
   readyForReports_ = false;
+  if (reconnectTaskHandle_ != nullptr) {
+    vTaskDelete(reconnectTaskHandle_);
+    reconnectTaskHandle_ = nullptr;
+  }
 
   const esp_err_t scanErr =
       esp_bt_gap_set_scan_mode(ESP_BT_NON_CONNECTABLE, ESP_BT_NON_DISCOVERABLE);
@@ -631,6 +677,18 @@ void ClassicBtControllerTransport::sendTaskTrampoline(void *param) {
   }
 }
 
+void ClassicBtControllerTransport::reconnectTaskTrampoline(void *param) {
+  auto *transport = static_cast<ClassicBtControllerTransport *>(param);
+  vTaskDelay(pdMS_TO_TICKS(kLastPeerReconnectDelayMs));
+
+  if (transport->hasPeerAddress_ && !transport->connected_) {
+    transport->attemptVirtualCablePlug(transport->lastPeerAddress_, "delayed-last-peer");
+  }
+
+  transport->reconnectTaskHandle_ = nullptr;
+  vTaskDelete(nullptr);
+}
+
 bool ClassicBtControllerTransport::pressButtons(
     uint32_t buttonsMask, uint16_t holdMs, uint16_t settleMs) {
   if (!beginExplicitInput()) {
@@ -667,10 +725,15 @@ bool ClassicBtControllerTransport::moveDirection(
 }
 
 bool ClassicBtControllerTransport::resetConnection(bool reconnectLastPeer) {
+  // Let the Switch initiate the HID connection from "Change Grip/Order".
+  // Proactive virtual-cable reconnects can race with the host's incoming
+  // connection while the ESP32 Bluetooth stack is restarting.
   const bool shouldReconnectLastPeer = reconnectLastPeer && hasPeerAddress_;
+  const bool requestedReconnectLastPeer = reconnectLastPeer && hasPeerAddress_;
   Serial.printf(
-      "INFO bt reset requested mode=stack-restart reconnect_last_peer=%s\n",
-      boolName(shouldReconnectLastPeer));
+      "INFO bt reset requested mode=stack-restart reconnect_last_peer=%s requested_last_peer=%s\n",
+      boolName(shouldReconnectLastPeer),
+      boolName(requestedReconnectLastPeer));
 
   shutdownClassicBluetooth();
 
@@ -747,6 +810,22 @@ void ClassicBtControllerTransport::printStatus(Print &output) const {
   output.println(lastDropReason_);
   output.print("INFO bt_ignored_report_count=");
   output.println(ignoredReportCount_);
+  output.print("INFO bt_intr_report_count=");
+  output.println(intrReportCount_);
+  output.print("INFO bt_last_intr_report=");
+  output.print(lastIntrReportId_);
+  output.print("/");
+  output.println(lastIntrReportLen_);
+  output.print("INFO bt_last_intr_subcmd=");
+  output.print(lastIntrSubcommand_);
+  output.print("/");
+  output.print(lastIntrArg0_);
+  output.print("/");
+  output.println(lastIntrArg1_);
+  output.print("INFO bt_reply_count=");
+  output.println(replyCount_);
+  output.print("INFO bt_last_reply=");
+  output.println(lastReplyLabel_);
   output.print("INFO bt_last_ignored_report=");
   output.print(lastIgnoredReportId_);
   output.print("/");
@@ -765,6 +844,14 @@ void ClassicBtControllerTransport::printStatus(Print &output) const {
   output.println(lastSendReportReason_);
   output.print("INFO bt_last_send_report_id=");
   output.println(lastSendReportId_);
+  output.print("INFO bt_report_congested=");
+  output.println(boolName(reportCongested_));
+  output.print("INFO bt_consecutive_send_failures=");
+  output.println(consecutiveSendReportFailures_);
+  output.print("INFO bt_input_report_submitted=");
+  output.println(inputReportSubmitCount_);
+  output.print("INFO bt_input_report_completed=");
+  output.println(inputReportSendEventCount_);
 
   if (hasPeerAddress_) {
     output.print("INFO bt_last_peer=");
@@ -938,7 +1025,7 @@ bool ClassicBtControllerTransport::repeatCurrentInputReport(
   bool loggedCongestionRetry = false;
 
   while (true) {
-    if (!sendCurrentInputReport(logFailure, false)) {
+    if (!sendCurrentInputReport(logFailure, true)) {
       if (shouldRetryAfterTransientSendFailure()) {
         if (congestionStartedAt == 0) {
           congestionStartedAt = millis();
@@ -984,6 +1071,41 @@ void ClassicBtControllerTransport::resetInputReportTracking() {
   consecutiveSendReportFailures_ = 0;
 }
 
+void ClassicBtControllerTransport::rememberPeerAddress(const uint8_t peerAddress[6]) {
+  const bool changed = !hasPeerAddress_ ||
+                       std::memcmp(lastPeerAddress_, peerAddress, sizeof(lastPeerAddress_)) != 0;
+  std::memcpy(lastPeerAddress_, peerAddress, sizeof(lastPeerAddress_));
+  hasPeerAddress_ = true;
+
+  if (changed) {
+    persistLastPeerAddress(peerAddress);
+  }
+}
+
+void ClassicBtControllerTransport::persistLastPeerAddress(const uint8_t peerAddress[6]) {
+  nvs_handle handle = 0;
+  esp_err_t err = nvs_open("storage", NVS_READWRITE, &handle);
+  if (err != ESP_OK) {
+    Serial.printf("WARN bt persist_peer open failed err=%s\n", esp_err_to_name(err));
+    return;
+  }
+
+  err = nvs_set_blob(handle, "peer_addr", peerAddress, 6);
+  if (err == ESP_OK) {
+    err = nvs_commit(handle);
+  }
+  nvs_close(handle);
+
+  if (err != ESP_OK) {
+    Serial.printf("WARN bt persist_peer failed err=%s\n", esp_err_to_name(err));
+    return;
+  }
+
+  Serial.printf(
+      "INFO bt persisted_peer=%s\n",
+      formatBluetoothAddress(peerAddress).c_str());
+}
+
 void ClassicBtControllerTransport::markControllerPaired() {
   if (!paired_) {
     resetInputReportTracking();
@@ -1020,6 +1142,8 @@ bool ClassicBtControllerTransport::sendSubcommandReply(
     return false;
   }
 
+  replyCount_ += 1;
+  lastReplyLabel_ = label;
   Serial.printf("INFO bt reply label=%s report=%u len=%u\n", label, reportId, length);
   return true;
 }
@@ -1047,6 +1171,26 @@ bool ClassicBtControllerTransport::attemptVirtualCablePlug(
   return true;
 }
 
+void ClassicBtControllerTransport::scheduleLastPeerReconnect(const char *reason) {
+  if (!hasPeerAddress_ || reconnectTaskHandle_ != nullptr) {
+    return;
+  }
+
+  Serial.printf(
+      "INFO bt reconnect scheduled reason=%s peer=%s delay_ms=%u\n",
+      reason,
+      formatBluetoothAddress(lastPeerAddress_).c_str(),
+      kLastPeerReconnectDelayMs);
+  xTaskCreatePinnedToCore(
+      &ClassicBtControllerTransport::reconnectTaskTrampoline,
+      "bt_reconnect_task",
+      3072,
+      this,
+      1,
+      &reconnectTaskHandle_,
+      0);
+}
+
 void ClassicBtControllerTransport::processIncomingReport(uint8_t reportId, uint16_t len, uint8_t *data) {
   if (len < 12 || data == nullptr) {
     const bool repeated = ignoredReportCount_ > 0 && lastIgnoredReportId_ == reportId &&
@@ -1056,13 +1200,29 @@ void ClassicBtControllerTransport::processIncomingReport(uint8_t reportId, uint1
     lastIgnoredReportLen_ = len;
     if (!repeated || ignoredReportCount_ <= 5 || (ignoredReportCount_ % 20) == 0) {
       Serial.printf(
-          "INFO bt intr ignored report=%u len=%u count=%lu\n",
+          "INFO bt intr ignored report=%u len=%u count=%lu data=",
           reportId,
           len,
           static_cast<unsigned long>(ignoredReportCount_));
+      if (data == nullptr) {
+        Serial.print("null");
+      } else {
+        const uint16_t loggedLength = len < 16 ? len : 16;
+        for (uint16_t index = 0; index < loggedLength; index += 1) {
+          Serial.printf("%02X", data[index]);
+        }
+      }
+      Serial.println();
     }
     return;
   }
+
+  intrReportCount_ += 1;
+  lastIntrReportId_ = reportId;
+  lastIntrReportLen_ = len;
+  lastIntrSubcommand_ = data[9];
+  lastIntrArg0_ = data[10];
+  lastIntrArg1_ = data[11];
 
   Serial.printf(
       "INFO bt intr report=%u len=%u subcmd=%u arg0=%u arg1=%u\n",
@@ -1073,6 +1233,18 @@ void ClassicBtControllerTransport::processIncomingReport(uint8_t reportId, uint1
       data[11]);
 
   if (data[9] == 2) {
+    const uint8_t *btAddress = esp_bt_dev_get_address();
+    if (btAddress != nullptr) {
+      setReply02BluetoothAddress(btAddress);
+      Serial.printf(
+          "INFO bt reply02_mac=%02X:%02X:%02X:%02X:%02X:%02X\n",
+          btAddress[0],
+          btAddress[1],
+          btAddress[2],
+          btAddress[3],
+          btAddress[4],
+          btAddress[5]);
+    }
     sendSubcommandReply(0x21, kReply02, sizeof(kReply02), "reply02");
     return;
   }
@@ -1129,7 +1301,9 @@ void ClassicBtControllerTransport::processIncomingReport(uint8_t reportId, uint1
     return;
   }
   if (data[9] == 48) {
-    markControllerPaired();
+    // UARTSwitchCon only treats 0x30 as "paired" for Joy-Con mode. In Pro
+    // Controller mode, Switch usually still needs the later 0x21/0x21 NFC/IR
+    // MCU step before the controller remains usable outside Change Grip/Order.
     sendSubcommandReply(0x21, kReply3001, sizeof(kReply3001), "reply3001");
     return;
   }
@@ -1152,8 +1326,7 @@ void ClassicBtControllerTransport::handleGapEvent(int event, void *rawParam) {
           param->auth_cmpl.stat,
           reinterpret_cast<const char *>(param->auth_cmpl.device_name));
       if (param->auth_cmpl.stat == ESP_BT_STATUS_SUCCESS) {
-        std::memcpy(lastPeerAddress_, param->auth_cmpl.bda, sizeof(lastPeerAddress_));
-        hasPeerAddress_ = true;
+        rememberPeerAddress(param->auth_cmpl.bda);
         // Let Switch initiate the HID control channel after authentication.
         // Proactively opening a virtual cable here can race with the host's own
         // incoming CTRL connection and trigger invalid-state rejects.
@@ -1217,12 +1390,11 @@ void ClassicBtControllerTransport::handleHidEvent(int event, void *rawParam) {
 
         if (param->register_app.in_use && param->register_app.bd_addr != nullptr) {
           reconnectLastPeerOnRegister_ = false;
-          attemptVirtualCablePlug(param->register_app.bd_addr, "register-app");
+          rememberPeerAddress(param->register_app.bd_addr);
+          scheduleLastPeerReconnect("register-app");
         } else if (reconnectLastPeerOnRegister_ && hasPeerAddress_) {
-          // Only explicit recovery resets should preferentially reconnect the
-          // previously authenticated host; ordinary pairing stays neutral.
           reconnectLastPeerOnRegister_ = false;
-          attemptVirtualCablePlug(lastPeerAddress_, "register-app-last-peer");
+          scheduleLastPeerReconnect("register-app-last-peer");
         } else {
           reconnectLastPeerOnRegister_ = false;
         }
@@ -1236,8 +1408,7 @@ void ClassicBtControllerTransport::handleHidEvent(int event, void *rawParam) {
       reportCongested_ = false;
       consecutiveSendReportFailures_ = 0;
       if (connected_) {
-        std::memcpy(lastPeerAddress_, param->open.bd_addr, sizeof(lastPeerAddress_));
-        hasPeerAddress_ = true;
+        rememberPeerAddress(param->open.bd_addr);
         esp_bt_gap_set_scan_mode(ESP_BT_NON_CONNECTABLE, ESP_BT_NON_DISCOVERABLE);
         ensureSendTask();
         sendCurrentInputReport(false);

--- a/firmware/esp32/src/classic_bt_controller_transport.h
+++ b/firmware/esp32/src/classic_bt_controller_transport.h
@@ -36,9 +36,12 @@ class ClassicBtControllerTransport : public ControllerTransport {
   bool beginExplicitInput();
   void endExplicitInput();
   void resetInputReportTracking();
+  void rememberPeerAddress(const uint8_t peerAddress[6]);
+  void persistLastPeerAddress(const uint8_t peerAddress[6]);
   void markControllerPaired();
   bool sendSubcommandReply(uint8_t reportId, const uint8_t *data, size_t length, const char *label);
   bool attemptVirtualCablePlug(const uint8_t peerAddress[6], const char *reason);
+  void scheduleLastPeerReconnect(const char *reason);
   void enterReconnectableState(const char *reason);
   void processIncomingReport(uint8_t reportId, uint16_t len, uint8_t *data);
   void handleGapEvent(int event, void *param);
@@ -47,6 +50,7 @@ class ClassicBtControllerTransport : public ControllerTransport {
   static void onGapEvent(int event, void *param);
   static void onHidEvent(int event, void *param);
   static void sendTaskTrampoline(void *param);
+  static void reconnectTaskTrampoline(void *param);
 
   static ClassicBtControllerTransport *instance_;
 
@@ -83,7 +87,16 @@ class ClassicBtControllerTransport : public ControllerTransport {
   uint8_t lastPeerAddress_[6] = {};
   bool hasPeerAddress_ = false;
   bool reconnectLastPeerOnRegister_ = false;
+  TaskHandle_t reconnectTaskHandle_ = nullptr;
   uint32_t ignoredReportCount_ = 0;
+  uint32_t intrReportCount_ = 0;
+  uint8_t lastIntrReportId_ = 0;
+  uint16_t lastIntrReportLen_ = 0;
+  uint8_t lastIntrSubcommand_ = 0;
+  uint8_t lastIntrArg0_ = 0;
+  uint8_t lastIntrArg1_ = 0;
+  uint32_t replyCount_ = 0;
+  const char *lastReplyLabel_ = "-";
   uint8_t lastIgnoredReportId_ = 0;
   uint16_t lastIgnoredReportLen_ = 0;
   uint8_t lastAclDisconnectReason_ = 0;


### PR DESCRIPTION

## Summary / 摘要

This PR improves ESP32 Classic Bluetooth controller reconnect stability for Switch / Switch Lite.

这个 PR 改善了 ESP32 Classic Bluetooth 模拟 Switch 手柄时的连接和重连稳定性，重点解决 Switch Lite 上配对后容易断开、断开后难以恢复的问题。

## Problem / 问题

Before this change, the controller could stay between broadcasting and connected states. Sometimes the controller icon appeared on the Switch and disappeared shortly after. On Switch Lite, pressing `A` to leave the `Change Grip/Order` page could switch back to native controls, and later button reports failed because the ESP32 was no longer ready.

之前的问题是：手柄经常在“广播中”和“连接已建立”之间反复切换；Switch 上手柄图标会出现又消失；Switch Lite 上按 `A` 退出“更改握法/顺序”页面后，可能切回原生手柄，之后网页继续发按键会失败。

Example log:

```text
WARN bt report skipped reason=not-ready connected=false paired=false
WARN execute failed message=controller input report failed
```

## Changes / 改动

- Reuse the last paired Switch peer when reconnecting.
- Delay virtual cable reconnect after HID registration.
- Use the actual ESP32 Bluetooth MAC in controller reply data.
- Avoid automatic Bluetooth resets while the Switch may still be handshaking.
- Add UI handling for disconnected Bluetooth controller state.
- Improve serial parsing when ACK and INFO output are concatenated.
- Add tests for controller status and reconnect behavior.

## Result / 效果

After the controller has paired once, reconnecting is much more reliable. If Switch Lite switches back to native controls, the UI now detects the disconnected state. In normal cases, clicking `Connect Controller` again is enough to reconnect without re-entering `Change Grip/Order`.

手柄成功配对过一次后，后续重连更稳定。如果 Switch Lite 切回原生手柄，网页会显示“手柄已断开”。通常只需要再次点击“连接手柄”即可恢复，不需要每次重新进入“更改握法/顺序”。

## Verification / 验证

```powershell
node --import tsx --test apps\desktop\test\controller-status.test.ts apps\desktop\test\firmware-flash.test.ts
npm.cmd run check
```

Manual test passed on Switch Lite + ESP32-WROOM over Classic Bluetooth.

已在 Switch Lite + ESP32-WROOM + Classic Bluetooth 环境下完成手动测试。