### PR TITLE
Add Switch Lite firmware support to the flasher site

### DIFF
--- a/.github/workflows/flasher-site-pages.yml
+++ b/.github/workflows/flasher-site-pages.yml
@@ -50,8 +50,10 @@ jobs:
           python -m pip install --upgrade pip
           python -m pip install platformio
 
-      - name: Build ESP32 firmware
-        run: python -m platformio run -d firmware/esp32 -e esp32dev_wireless
+      - name: Build ESP32 firmware (standard + Switch Lite)
+        run: |
+          python -m platformio run -d firmware/esp32 -e esp32dev_wireless
+          python -m platformio run -d firmware/esp32 -e esp32dev_wireless_switch_lite
 
       - name: Build flasher site
         run: npm run build --prefix site/flasher

--- a/site/flasher/index.html
+++ b/site/flasher/index.html
@@ -49,8 +49,13 @@
           <section class="panel">
             <div class="panel-head">
               <h2>固件版本</h2>
-              <p>这里展示当前站点提供的主线固件发布信息。</p>
+              <p>这里展示当前站点提供的固件发布信息，可在标准 Switch 与 Switch Lite 模式间切换。</p>
             </div>
+            <div class="field-row">
+              <label for="firmware-switch-model">目标机型</label>
+              <select id="firmware-switch-model"></select>
+            </div>
+            <p id="firmware-switch-model-description" class="field-help"></p>
             <dl class="meta-list">
               <div class="meta-row">
                 <dt>Version</dt>
@@ -62,7 +67,7 @@
               </div>
               <div class="meta-row">
                 <dt>Manifest</dt>
-                <dd>./firmware/manifest.json</dd>
+                <dd id="firmware-manifest-path">./firmware/manifest.json</dd>
               </div>
             </dl>
             <div>

--- a/site/flasher/scripts/build-pages.mjs
+++ b/site/flasher/scripts/build-pages.mjs
@@ -4,13 +4,14 @@ import path from "node:path";
 
 import {
   createFirmwareManifest,
+  getFirmwareVariant,
+  listFirmwareVariants,
   readFirmwareFlashPlan,
   siteRoot,
 } from "./firmware-site.mjs";
 
 const webBuildRoot = path.join(siteRoot, "dist", "web");
 const pagesRoot = path.join(siteRoot, "dist", "pages");
-const firmwareOutputRoot = path.join(pagesRoot, "firmware", "esp32dev_wireless");
 
 async function assertFileExists(filePath) {
   if (!existsSync(filePath)) {
@@ -25,26 +26,44 @@ async function assertFileExists(filePath) {
 
 async function main() {
   await assertFileExists(path.join(webBuildRoot, "index.html"));
-  const firmwareParts = await readFirmwareFlashPlan();
+  const firmwareVariants = listFirmwareVariants();
+  const firmwarePlanByModel = new Map();
 
-  for (const part of firmwareParts) {
-    await assertFileExists(part.sourcePath);
+  for (const variant of firmwareVariants) {
+    const firmwareParts = await readFirmwareFlashPlan(variant.switchModelId);
+    for (const part of firmwareParts) {
+      await assertFileExists(part.sourcePath);
+    }
+    firmwarePlanByModel.set(variant.switchModelId, firmwareParts);
   }
 
   await rm(pagesRoot, { recursive: true, force: true });
-  await mkdir(firmwareOutputRoot, { recursive: true });
   await cp(webBuildRoot, pagesRoot, { recursive: true });
 
-  for (const part of firmwareParts) {
-    await cp(part.sourcePath, path.join(firmwareOutputRoot, part.publishFileName));
+  for (const variant of firmwareVariants) {
+    const firmwareOutputRoot = path.join(pagesRoot, "firmware", variant.environmentId);
+    await mkdir(firmwareOutputRoot, { recursive: true });
+
+    for (const part of firmwarePlanByModel.get(variant.switchModelId) ?? []) {
+      await cp(part.sourcePath, path.join(firmwareOutputRoot, part.publishFileName));
+    }
   }
 
-  const manifest = await createFirmwareManifest();
-  await writeFile(
-    path.join(pagesRoot, "firmware", "manifest.json"),
-    `${JSON.stringify(manifest, null, 2)}\n`,
-    "utf8",
-  );
+  for (const variant of firmwareVariants) {
+    const manifest = await createFirmwareManifest(variant.switchModelId);
+    await writeFile(
+      path.join(pagesRoot, "firmware", variant.manifestFileName),
+      `${JSON.stringify(manifest, null, 2)}\n`,
+      "utf8",
+    );
+  }
+
+  const defaultManifestVariant = getFirmwareVariant("switch");
+  if (defaultManifestVariant.manifestFileName !== "manifest.json") {
+    const manifest = await createFirmwareManifest("switch");
+    await writeFile(path.join(pagesRoot, "firmware", "manifest.json"), `${JSON.stringify(manifest, null, 2)}\n`, "utf8");
+  }
+
   await writeFile(path.join(pagesRoot, ".nojekyll"), "", "utf8");
 }
 

--- a/site/flasher/scripts/firmware-site.mjs
+++ b/site/flasher/scripts/firmware-site.mjs
@@ -10,15 +10,28 @@ const __filename = fileURLToPath(import.meta.url);
 const __dirname = path.dirname(__filename);
 
 export const siteRoot = path.resolve(__dirname, "..");
-export const firmwareBuildRoot = path.join(
-  repoRoot,
-  "firmware",
-  "esp32",
-  ".pio",
-  "build",
-  "esp32dev_wireless",
-);
-export const flasherArgsPath = path.join(firmwareBuildRoot, "flasher_args.json");
+
+const FIRMWARE_VARIANTS = {
+  switch: {
+    switchModelId: "switch",
+    switchModelLabel: "Switch / OLED / V2",
+    switchModelDescription: "标准 Switch 固件行为。",
+    environmentId: "esp32dev_wireless",
+    boardId: "esp32dev_wireless",
+    boardLabel: "ESP32-WROOM-32 / ESP-32S",
+    manifestFileName: "manifest.json",
+  },
+  switch_lite: {
+    switchModelId: "switch_lite",
+    switchModelLabel: "Switch Lite",
+    switchModelDescription:
+      "Switch Lite 对蓝牙 HID 时序更敏感；此模式会切换到启用 SWITCH_LITE 的专用构建（禁用 BT modem sleep、固定发送节奏并延长拥塞重试）以提升配对与按键稳定性。",
+    environmentId: "esp32dev_wireless_switch_lite",
+    boardId: "esp32dev_wireless_switch_lite",
+    boardLabel: "ESP32-WROOM-32 / ESP-32S（Switch Lite 模式）",
+    manifestFileName: "manifest.switch_lite.json",
+  },
+};
 
 const legacyPublishedFileNamesBySource = new Map([
   ["bootloader/bootloader.bin", "bootloader.bin"],
@@ -39,6 +52,27 @@ function parseFlashOffset(offset) {
   }
 
   return parsed;
+}
+
+export function listFirmwareVariants() {
+  return Object.values(FIRMWARE_VARIANTS);
+}
+
+export function getFirmwareVariant(switchModelId = "switch") {
+  const variant = FIRMWARE_VARIANTS[switchModelId];
+  if (!variant) {
+    throw new Error(`Unsupported switch model for firmware site: ${switchModelId}`);
+  }
+
+  return variant;
+}
+
+export function getFirmwareBuildRoot(environmentId) {
+  return path.join(repoRoot, "firmware", "esp32", ".pio", "build", environmentId);
+}
+
+export function getFlasherArgsPath(environmentId) {
+  return path.join(getFirmwareBuildRoot(environmentId), "flasher_args.json");
 }
 
 export function normalizePublishedFileName(sourceRelativePath) {
@@ -71,7 +105,7 @@ export function buildFirmwareFlashPlanFromArgs(flasherArgs) {
     .sort((left, right) => left.offset - right.offset);
 }
 
-function firmwareSourcePathCandidates(sourceRelativePath) {
+function firmwareSourcePathCandidates(firmwareBuildRoot, sourceRelativePath) {
   const candidates = [
     path.join(firmwareBuildRoot, sourceRelativePath),
     path.join(firmwareBuildRoot, path.basename(sourceRelativePath)),
@@ -86,7 +120,15 @@ function firmwareSourcePathCandidates(sourceRelativePath) {
 }
 
 export function resolveFirmwareSourcePath(sourceRelativePath) {
-  for (const candidate of firmwareSourcePathCandidates(sourceRelativePath)) {
+  const defaultVariant = getFirmwareVariant("switch");
+  return resolveFirmwareSourcePathForBuildRoot(
+    getFirmwareBuildRoot(defaultVariant.environmentId),
+    sourceRelativePath,
+  );
+}
+
+export function resolveFirmwareSourcePathForBuildRoot(firmwareBuildRoot, sourceRelativePath) {
+  for (const candidate of firmwareSourcePathCandidates(firmwareBuildRoot, sourceRelativePath)) {
     if (existsSync(candidate)) {
       return candidate;
     }
@@ -95,12 +137,16 @@ export function resolveFirmwareSourcePath(sourceRelativePath) {
   throw new Error(`Missing required firmware file for flash part: ${sourceRelativePath}`);
 }
 
-export async function readFirmwareFlashPlan() {
+export async function readFirmwareFlashPlan(switchModelId = "switch") {
+  const variant = getFirmwareVariant(switchModelId);
+  const firmwareBuildRoot = getFirmwareBuildRoot(variant.environmentId);
+  const flasherArgsPath = getFlasherArgsPath(variant.environmentId);
   const flasherArgs = JSON.parse(await readFile(flasherArgsPath, "utf8"));
+
   return buildFirmwareFlashPlanFromArgs(flasherArgs).map((part) => ({
     ...part,
-    manifestPath: `esp32dev_wireless/${part.publishFileName}`,
-    sourcePath: resolveFirmwareSourcePath(part.sourceRelativePath),
+    manifestPath: `${variant.environmentId}/${part.publishFileName}`,
+    sourcePath: resolveFirmwareSourcePathForBuildRoot(firmwareBuildRoot, part.sourceRelativePath),
   }));
 }
 
@@ -109,18 +155,19 @@ export async function sha256File(filePath) {
   return createHash("sha256").update(content).digest("hex");
 }
 
-export async function assertFirmwareFiles() {
-  for (const part of await readFirmwareFlashPlan()) {
+export async function assertFirmwareFiles(switchModelId = "switch") {
+  for (const part of await readFirmwareFlashPlan(switchModelId)) {
     if (!existsSync(part.sourcePath)) {
       throw new Error(`Missing required firmware file: ${part.sourcePath}`);
     }
   }
 }
 
-export async function createFirmwareManifest() {
-  await assertFirmwareFiles();
+export async function createFirmwareManifest(switchModelId = "switch") {
+  const variant = getFirmwareVariant(switchModelId);
+  await assertFirmwareFiles(switchModelId);
   const { version, desktopReleaseUrl } = await readReleaseInfo();
-  const firmwareParts = await readFirmwareFlashPlan();
+  const firmwareParts = await readFirmwareFlashPlan(switchModelId);
   const sha256 = [];
 
   for (const part of firmwareParts) {
@@ -144,8 +191,11 @@ export async function createFirmwareManifest() {
       },
     ],
     metadata: {
-      boardId: "esp32dev_wireless",
-      label: "ESP32-WROOM-32 / ESP-32S",
+      boardId: variant.boardId,
+      label: variant.boardLabel,
+      switchModelId: variant.switchModelId,
+      switchModelLabel: variant.switchModelLabel,
+      switchModelDescription: variant.switchModelDescription,
       desktopReleaseUrl,
       generatedAt: new Date().toISOString(),
       sha256,

--- a/site/flasher/scripts/verify-pages.mjs
+++ b/site/flasher/scripts/verify-pages.mjs
@@ -3,11 +3,14 @@ import path from "node:path";
 import { existsSync } from "node:fs";
 import { readFile, stat } from "node:fs/promises";
 
-import { createFirmwareManifest, readFirmwareFlashPlan, siteRoot } from "./firmware-site.mjs";
+import {
+  createFirmwareManifest,
+  listFirmwareVariants,
+  readFirmwareFlashPlan,
+  siteRoot,
+} from "./firmware-site.mjs";
 
 const pagesRoot = path.join(siteRoot, "dist", "pages");
-const manifestPath = path.join(pagesRoot, "firmware", "manifest.json");
-const publishedFirmwareRoot = path.join(pagesRoot, "firmware", "esp32dev_wireless");
 
 async function assertFileExists(filePath) {
   if (!existsSync(filePath)) {
@@ -22,33 +25,44 @@ async function assertFileExists(filePath) {
 
 async function main() {
   await assertFileExists(path.join(pagesRoot, "index.html"));
-  await assertFileExists(manifestPath);
+  const firmwareVariants = listFirmwareVariants();
 
-  const flashPlan = await readFirmwareFlashPlan();
-  for (const part of flashPlan) {
-    await assertFileExists(path.join(publishedFirmwareRoot, part.publishFileName));
+  for (const variant of firmwareVariants) {
+    const manifestPath = path.join(pagesRoot, "firmware", variant.manifestFileName);
+    const publishedFirmwareRoot = path.join(pagesRoot, "firmware", variant.environmentId);
+    await assertFileExists(manifestPath);
+
+    const flashPlan = await readFirmwareFlashPlan(variant.switchModelId);
+    for (const part of flashPlan) {
+      await assertFileExists(path.join(publishedFirmwareRoot, part.publishFileName));
+    }
+
+    const actualManifest = JSON.parse(await readFile(manifestPath, "utf8"));
+    const expectedManifest = await createFirmwareManifest(variant.switchModelId);
+
+    assert.equal(actualManifest.name, expectedManifest.name, "manifest name should match");
+    assert.equal(actualManifest.version, expectedManifest.version, "manifest version should match");
+    assert.equal(
+      actualManifest.metadata?.desktopReleaseUrl,
+      expectedManifest.metadata?.desktopReleaseUrl,
+      "desktop release URL should match the derived release info",
+    );
+    assert.deepEqual(
+      actualManifest.builds,
+      expectedManifest.builds,
+      "manifest firmware parts should match the normalized flash plan",
+    );
+    assert.deepEqual(
+      actualManifest.metadata?.sha256,
+      expectedManifest.metadata?.sha256,
+      "manifest SHA256 metadata should match the published firmware files",
+    );
+    assert.equal(
+      actualManifest.metadata?.switchModelId,
+      variant.switchModelId,
+      "manifest switch model should match variant",
+    );
   }
-
-  const actualManifest = JSON.parse(await readFile(manifestPath, "utf8"));
-  const expectedManifest = await createFirmwareManifest();
-
-  assert.equal(actualManifest.name, expectedManifest.name, "manifest name should match");
-  assert.equal(actualManifest.version, expectedManifest.version, "manifest version should match");
-  assert.equal(
-    actualManifest.metadata?.desktopReleaseUrl,
-    expectedManifest.metadata?.desktopReleaseUrl,
-    "desktop release URL should match the derived release info",
-  );
-  assert.deepEqual(
-    actualManifest.builds,
-    expectedManifest.builds,
-    "manifest firmware parts should match the normalized flash plan",
-  );
-  assert.deepEqual(
-    actualManifest.metadata?.sha256,
-    expectedManifest.metadata?.sha256,
-    "manifest SHA256 metadata should match the published firmware files",
-  );
 }
 
 main().catch((error) => {

--- a/site/flasher/src/main.ts
+++ b/site/flasher/src/main.ts
@@ -14,6 +14,9 @@ interface FirmwareManifest {
   }>;
   metadata?: {
     boardId?: string;
+    switchModelId?: string;
+    switchModelLabel?: string;
+    switchModelDescription?: string;
     desktopReleaseUrl?: string;
     label?: string;
     sha256?: Array<{
@@ -44,6 +47,34 @@ interface FlashDetectionCardState {
   buttonLabel: string;
   buttonDisabled: boolean;
 }
+
+type SwitchModelId = "switch" | "switch_lite";
+
+interface SwitchModelDefinition {
+  id: SwitchModelId;
+  label: string;
+  description: string;
+  manifestPath: string;
+}
+
+const SWITCH_MODELS: SwitchModelDefinition[] = [
+  {
+    id: "switch",
+    label: "Switch / OLED / V2",
+    description: "标准 Switch 固件行为。",
+    manifestPath: "./firmware/manifest.json",
+  },
+  {
+    id: "switch_lite",
+    label: "Switch Lite",
+    description:
+      "Switch Lite 对蓝牙 HID 时序更敏感；会切换到启用 SWITCH_LITE 的专用构建（禁用 BT modem sleep、固定发送节奏并延长拥塞重试）以提升配对与按键稳定性。",
+    manifestPath: "./firmware/manifest.switch_lite.json",
+  },
+];
+
+const DEFAULT_SWITCH_MODEL_ID: SwitchModelId = "switch";
+const DEFAULT_SWITCH_MODEL = SWITCH_MODELS[0] as SwitchModelDefinition;
 
 const FLASH_DETECTION_BAUD_RATE = 115200;
 const FLASH_DETECTION_BUTTON_LABEL = "检测当前开发板";
@@ -79,7 +110,10 @@ const els = {
   desktopStepLabel: document.getElementById("desktop-step-label") as HTMLElement,
   desktopFlowLabel: document.getElementById("desktop-flow-label") as HTMLElement,
   firmwareVersion: document.getElementById("firmware-version") as HTMLElement,
+  firmwareSwitchModel: document.getElementById("firmware-switch-model") as HTMLSelectElement,
+  firmwareSwitchModelDescription: document.getElementById("firmware-switch-model-description") as HTMLElement,
   firmwareBoardLabel: document.getElementById("firmware-board-label") as HTMLElement,
+  firmwareManifestPath: document.getElementById("firmware-manifest-path") as HTMLElement,
   firmwarePartsList: document.getElementById("firmware-parts-list") as HTMLUListElement,
   firmwareShaList: document.getElementById("firmware-sha-list") as HTMLUListElement,
   firmwareInstallButton: document.getElementById("firmware-install-button") as InstallButtonElement,
@@ -87,6 +121,29 @@ const els = {
 
 const fallbackDesktopReleaseUrl = els.desktopDownloadLink.href;
 let hasFlashDetectionResult = false;
+let selectedSwitchModelId: SwitchModelId = DEFAULT_SWITCH_MODEL_ID;
+
+function findSwitchModel(modelId: string): SwitchModelDefinition {
+  return SWITCH_MODELS.find((model) => model.id === modelId) ?? DEFAULT_SWITCH_MODEL;
+}
+
+function getSelectedSwitchModel(): SwitchModelDefinition {
+  return findSwitchModel(selectedSwitchModelId);
+}
+
+function renderSwitchModelPicker(): void {
+  els.firmwareSwitchModel.replaceChildren();
+
+  for (const model of SWITCH_MODELS) {
+    const option = document.createElement("option");
+    option.value = model.id;
+    option.textContent = model.label;
+    els.firmwareSwitchModel.append(option);
+  }
+
+  els.firmwareSwitchModel.value = selectedSwitchModelId;
+  els.firmwareSwitchModelDescription.textContent = getSelectedSwitchModel().description;
+}
 
 function setCardTone(card: HTMLElement, tone: "idle" | "success" | "warning" | "error"): void {
   card.classList.remove("status-idle", "status-success", "status-warning", "status-error");
@@ -336,9 +393,12 @@ function renderDesktopRelease(version: string, desktopReleaseUrl: string): void 
   els.desktopFlowLabel.textContent = desktopLabel;
 }
 
-function renderManifest(manifest: FirmwareManifest): void {
+function renderManifest(manifest: FirmwareManifest, switchModel: SwitchModelDefinition): void {
   els.firmwareVersion.textContent = manifest.version;
   els.firmwareBoardLabel.textContent = manifest.metadata?.label ?? "ESP32-WROOM-32 / ESP-32S";
+  els.firmwareManifestPath.textContent = switchModel.manifestPath;
+  els.firmwareSwitchModelDescription.textContent =
+    manifest.metadata?.switchModelDescription ?? switchModel.description;
   els.firmwarePartsList.innerHTML = "";
   els.firmwareShaList.innerHTML = "";
 
@@ -356,24 +416,28 @@ function renderManifest(manifest: FirmwareManifest): void {
 
   renderDesktopRelease(manifest.version, manifest.metadata?.desktopReleaseUrl ?? fallbackDesktopReleaseUrl);
   renderBrowserSupport(manifest.version);
-  els.firmwareInstallButton.manifest = "./firmware/manifest.json";
+  els.firmwareInstallButton.manifest = switchModel.manifestPath;
   els.firmwareInstallButton.showLog = true;
   els.firmwareInstallButton.eraseFirst = false;
 }
 
 async function loadManifest(): Promise<void> {
+  const switchModel = getSelectedSwitchModel();
+
   try {
-    const response = await fetch("./firmware/manifest.json");
+    const response = await fetch(switchModel.manifestPath);
     if (!response.ok) {
       throw new Error(`HTTP ${response.status}`);
     }
 
     const manifest = (await response.json()) as FirmwareManifest;
-    renderManifest(manifest);
+    renderManifest(manifest, switchModel);
   } catch (error) {
     const message = error instanceof Error ? error.message : String(error);
-    els.firmwareVersion.textContent = message;
+    els.firmwareVersion.textContent = `${message} (${switchModel.manifestPath})`;
     els.firmwareBoardLabel.textContent = "-";
+    els.firmwareManifestPath.textContent = switchModel.manifestPath;
+    els.firmwareSwitchModelDescription.textContent = switchModel.description;
     els.firmwarePartsList.innerHTML = "";
     els.firmwareShaList.innerHTML = "";
   }
@@ -382,6 +446,14 @@ async function loadManifest(): Promise<void> {
 async function bootstrap(): Promise<void> {
   renderBrowserSupport();
   renderFlashDetectionIntro();
+  renderSwitchModelPicker();
+
+  els.firmwareSwitchModel.addEventListener("change", () => {
+    selectedSwitchModelId = findSwitchModel(els.firmwareSwitchModel.value).id;
+    els.firmwareSwitchModelDescription.textContent = getSelectedSwitchModel().description;
+    void loadManifest();
+  });
+
   els.flashDetectButton.addEventListener("click", () => {
     void handleFlashDetection();
   });

--- a/site/flasher/src/styles.css
+++ b/site/flasher/src/styles.css
@@ -135,6 +135,33 @@ a {
   line-height: 1.6;
 }
 
+.field-row {
+  display: grid;
+  gap: 8px;
+  margin-top: 16px;
+}
+
+.field-row label {
+  color: var(--muted);
+  font-size: 14px;
+}
+
+.field-row select {
+  width: 100%;
+  border: 1px solid rgba(72, 50, 28, 0.18);
+  border-radius: 12px;
+  background: rgba(255, 252, 246, 0.96);
+  color: var(--text);
+  font-size: 15px;
+  padding: 10px 12px;
+}
+
+.field-help {
+  margin: 10px 0 0;
+  color: var(--muted);
+  line-height: 1.6;
+}
+
 .status-card {
   border-radius: 18px;
   border: 1px solid rgba(72, 50, 28, 0.08);

--- a/site/flasher/vite.config.mjs
+++ b/site/flasher/vite.config.mjs
@@ -7,6 +7,7 @@ import { defineConfig } from "vite";
 
 import {
   createFirmwareManifest,
+  listFirmwareVariants,
   readFirmwareFlashPlan,
 } from "./scripts/firmware-site.mjs";
 
@@ -14,15 +15,24 @@ const __filename = fileURLToPath(import.meta.url);
 const __dirname = path.dirname(__filename);
 
 function firmwareDevPlugin() {
+  const variants = listFirmwareVariants();
+  const variantByManifestPath = new Map(
+    variants.map((variant) => [`/firmware/${variant.manifestFileName}`, variant]),
+  );
+  const variantByEnvironmentId = new Map(
+    variants.map((variant) => [variant.environmentId, variant]),
+  );
+
   return {
     name: "friend-maker-firmware-dev",
     configureServer(server) {
       server.middlewares.use(async (request, response, next) => {
         const url = request.url?.split("?")[0] ?? "";
+        const manifestVariant = variantByManifestPath.get(url);
 
-        if (url === "/firmware/manifest.json") {
+        if (manifestVariant) {
           try {
-            const manifest = await createFirmwareManifest();
+            const manifest = await createFirmwareManifest(manifestVariant.switchModelId);
             response.statusCode = 200;
             response.setHeader("Content-Type", "application/json; charset=utf-8");
             response.end(`${JSON.stringify(manifest, null, 2)}\n`);
@@ -35,18 +45,26 @@ function firmwareDevPlugin() {
           return;
         }
 
-        const match = /^\/firmware\/esp32dev_wireless\/([^/]+)$/u.exec(url);
-        if (!match?.[1]) {
+        const match = /^\/firmware\/([^/]+)\/([^/]+)$/u.exec(url);
+        const environmentId = match?.[1];
+        const publishFileName = match?.[2];
+        if (!environmentId || !publishFileName) {
           next();
           return;
         }
 
-        const firmwareParts = await readFirmwareFlashPlan();
-        const part = firmwareParts.find((entry) => entry.publishFileName === match[1]);
+        const variant = variantByEnvironmentId.get(environmentId);
+        if (!variant) {
+          next();
+          return;
+        }
+
+        const firmwareParts = await readFirmwareFlashPlan(variant.switchModelId);
+        const part = firmwareParts.find((entry) => entry.publishFileName === publishFileName);
         if (!part) {
           response.statusCode = 404;
           response.setHeader("Content-Type", "application/json; charset=utf-8");
-          response.end(`${JSON.stringify({ error: `Unknown firmware file: ${match[1]}` })}\n`);
+          response.end(`${JSON.stringify({ error: `Unknown firmware file: ${publishFileName}` })}\n`);
           return;
         }
 


### PR DESCRIPTION
Introduce support for multiple firmware variants (e.g. Switch and Switch Lite) across the site and build tooling. 

Added a FIRMWARE_VARIANTS map and helper functions (list/get/getFirmwareBuildRoot/getFlasherArgsPath) in firmware-site.mjs, updated path resolution to use per-variant build roots, and included switch model metadata (id/label/description) and variant-specific manifest filenames. 

The build-pages.mjs and verify-pages.mjs now iterate variants: copying variant-specific firmware files, emitting per-variant manifests, and validating each variant; the original manifest.json is still written for the default "switch" variant for compatibility. Vite dev server plugin was updated to serve variant manifests and firmware files during development. 

Frontend changes (index.html, main.ts, styles.css):
add a model picker UI, display per-model manifest path and description, and load the selected variant's manifest so the install button and UI reflect the chosen firmware variant. 

Overall this enables building, serving, and selecting different firmware builds for different Switch models.

NOTE: I was _not_ able to verify the flasher site working at local, I tried hold the [boot] button while clicking the connect, the frontend always return this error:

>  检测失败
  读取 Flash 容量时出了点问题
  读到了 Flash ID，但没法识别容量：0xFFFFFF

I verified by this command
```
pio pkg exec -p tool-esptoolpy -- esptool.py --chip esp32 --port /dev/cu.usbserial-0001 --baud 115200 flash_id
```
Here is the result
> Using tool-esptoolpy@2.41100.0 package
esptool.py v4.11.0
Serial port /dev/cu.usbserial-0001
Connecting....
Chip is ESP32-D0WDQ6 (revision v1.0)
Features: WiFi, BT, Dual Core, 240MHz, VRef calibration in efuse, Coding Scheme None
Crystal is 40MHz
MAC: 30:c6:f7:37:7d:38
Uploading stub...
Running stub...
Stub running...
Manufacturer: 5e
Device: 4016
Detected flash size: 4MB
Flash voltage set by a strapping pin to 3.3V
Hard resetting via RTS pin...
