### PR TITLE
Fix studio layout overflow

### DIFF
--- a/apps/desktop/src/web/static/app.js
+++ b/apps/desktop/src/web/static/app.js
@@ -32,7 +32,7 @@ function confirmUi(message) {
 
 const PANEL_LAYOUT_STORAGE_KEY = "friendmaker.panelLayout.v1";
 const PANEL_LAYOUT_RATIO_MIN = 0.08;
-const STUDIO_PREVIEW_COLUMN_MIN_PX = 568;
+const STUDIO_PREVIEW_COLUMN_MIN_PX = 300;
 const RECENTER_DIAGNOSTIC_INPUT_CONFIG_COMMAND = "CFG INPUT 65 45 1800";
 const RECENTER_DIAGNOSTIC_STICK_LEFT_COMMAND = "STICK -1 0 2000";
 const RECENTER_DIAGNOSTIC_STICK_UP_COMMAND = "STICK 0 -1 2000";
@@ -43,7 +43,7 @@ const PANEL_LAYOUTS = {
       count: 3,
       vars: ["--layout-studio-col-1", "--layout-studio-col-2", "--layout-studio-col-3"],
       defaults: [0.95, 1, 0.82],
-      minPixels: [250, STUDIO_PREVIEW_COLUMN_MIN_PX, 190],
+      minPixels: [260, STUDIO_PREVIEW_COLUMN_MIN_PX, 150],
     },
     rows: {
       count: 2,

--- a/apps/desktop/src/web/static/styles.css
+++ b/apps/desktop/src/web/static/styles.css
@@ -28,7 +28,7 @@
   --sidebar-width: 200px;
   --toolbar-height: 40px;
   --splitter-size: 8px;
-  --studio-preview-column-min: 568px;
+  --studio-preview-column-min: 300px;
   --radius-sm: 6px;
   --radius-md: 10px;
   --radius-lg: 16px;
@@ -426,8 +426,7 @@ textarea:disabled {
 .workspace-content {
   min-width: 0;
   min-height: 0;
-  overflow-x: auto;
-  overflow-y: hidden;
+  overflow: hidden;
 }
 
 .page {
@@ -442,9 +441,9 @@ textarea:disabled {
 }
 
 .page[data-page="studio"] {
-  width: max-content;
-  min-width: 100%;
-  overflow: visible;
+  width: 100%;
+  min-width: 0;
+  overflow: hidden;
 }
 
 .grid,
@@ -460,15 +459,15 @@ textarea:disabled {
 }
 
 .grid {
-  width: max-content;
-  min-width: 100%;
-  overflow: visible;
+  width: 100%;
+  min-width: 0;
+  overflow: hidden;
   grid-template-columns:
-    minmax(250px, var(--layout-studio-col-1, 0.95fr))
+    minmax(260px, var(--layout-studio-col-1, 0.95fr))
     var(--splitter-size)
     minmax(var(--studio-preview-column-min), var(--layout-studio-col-2, 1fr))
     var(--splitter-size)
-    minmax(190px, var(--layout-studio-col-3, 0.82fr));
+    minmax(150px, var(--layout-studio-col-3, 0.82fr));
   grid-template-rows:
     minmax(260px, var(--layout-studio-row-1, 1.15fr))
     var(--splitter-size)
@@ -543,7 +542,7 @@ textarea:disabled {
   grid-column: 3;
   grid-row: 1 / -1;
   min-height: 0;
-  min-width: var(--studio-preview-column-min);
+  min-width: 0;
   display: flex;
   flex-direction: column;
   align-items: stretch;
@@ -1314,8 +1313,9 @@ input[type="range"] {
   place-items: center;
   flex: 0 0 auto;
   align-self: center;
-  width: calc(520px + 24px);
-  height: calc(520px + 24px);
+  width: min(100%, calc(520px + 24px));
+  max-width: 100%;
+  aspect-ratio: 1;
   padding: 12px;
   border: 1px solid var(--divider);
   border-radius: var(--radius-lg);
@@ -1337,8 +1337,10 @@ input[type="range"] {
   position: relative;
   display: grid;
   place-items: center;
-  width: 520px;
-  height: 520px;
+  width: 100%;
+  max-width: 520px;
+  height: auto;
+  aspect-ratio: 1;
   overflow: hidden;
   border: 1px solid var(--ac-edge);
   border-radius: var(--radius-sm);
@@ -1786,11 +1788,11 @@ input[type="range"] {
 @media (max-width: 1180px) {
   .grid {
     grid-template-columns:
-      minmax(250px, var(--layout-studio-col-1, 0.95fr))
+      minmax(260px, var(--layout-studio-col-1, 0.95fr))
       var(--splitter-size)
       minmax(var(--studio-preview-column-min), var(--layout-studio-col-2, 1fr))
       var(--splitter-size)
-      minmax(190px, var(--layout-studio-col-3, 0.82fr));
+      minmax(150px, var(--layout-studio-col-3, 0.82fr));
     grid-template-rows:
       minmax(260px, var(--layout-studio-row-1, 1.15fr))
       var(--splitter-size)

--- a/apps/desktop/test/preview-layout.test.ts
+++ b/apps/desktop/test/preview-layout.test.ts
@@ -4,33 +4,92 @@ import path from "node:path";
 import { test } from "node:test";
 
 const webStaticRoot = path.resolve("apps/desktop/src/web/static");
+const electronRoot = path.resolve("apps/desktop/src/electron");
 
-test("studio preview column keeps a shared scroller and a fixed-size canvas", async () => {
-  const [indexSource, stylesSource, appSource] = await Promise.all([
+function readPxValue(source: string, pattern: RegExp, label: string): number {
+  const match = pattern.exec(source);
+  const value = match?.[1];
+  assert.ok(value, `Missing ${label}`);
+  return Number(value);
+}
+
+function readCssBlock(source: string, selector: string): string {
+  const escapedSelector = selector.replace(/[.*+?^${}()|[\]\\]/gu, "\\$&");
+  const match = new RegExp(`${escapedSelector}\\s*\\{([\\s\\S]*?)\\}`, "u").exec(source);
+  const block = match?.[1];
+  assert.ok(block, `Missing ${selector} CSS block`);
+  return block;
+}
+
+function readStudioColumnMinimums(appSource: string): number[] {
+  const constants = new Map<string, number>();
+  for (const match of appSource.matchAll(/const\s+([A-Z0-9_]+)\s*=\s*(\d+);/gu)) {
+    const name = match[1];
+    const value = match[2];
+
+    if (name && value) {
+      constants.set(name, Number(value));
+    }
+  }
+
+  const studioColumnsMatch = /studio:\s*\{[\s\S]*?columns:\s*\{[\s\S]*?minPixels:\s*\[([^\]]+)\]/u.exec(appSource);
+  const minimums = studioColumnsMatch?.[1];
+  assert.ok(minimums, "Missing studio column minimums");
+
+  return minimums
+    .split(",")
+    .map((part) => part.trim())
+    .map((part) => constants.get(part) ?? Number(part));
+}
+
+test("studio layout fits the Electron minimum window without horizontal page overflow", async () => {
+  const [indexSource, stylesSource, appSource, electronSource] = await Promise.all([
     readFile(path.join(webStaticRoot, "index.html"), "utf8"),
     readFile(path.join(webStaticRoot, "styles.css"), "utf8"),
     readFile(path.join(webStaticRoot, "app.js"), "utf8"),
+    readFile(path.join(electronRoot, "main.ts"), "utf8"),
   ]);
 
   assert.match(indexSource, /<div class="preview-column">[\s\S]*<section class="panel panel-preview">/u);
   assert.match(indexSource, /<section id="official-palette-panel" class="panel panel-official-palette hidden">/u);
-  assert.match(stylesSource, /--studio-preview-column-min:\s*568px;/u);
-  assert.match(stylesSource, /\.workspace-content\s*\{[\s\S]*overflow-x:\s*auto;[\s\S]*overflow-y:\s*hidden;/u);
-  assert.match(stylesSource, /\.page\[data-page="studio"\]\s*\{[\s\S]*width:\s*max-content;[\s\S]*min-width:\s*100%;[\s\S]*overflow:\s*visible;/u);
-  assert.match(stylesSource, /\.grid\s*\{[\s\S]*width:\s*max-content;[\s\S]*min-width:\s*100%;[\s\S]*minmax\(var\(--studio-preview-column-min\),\s*var\(--layout-studio-col-2,\s*1fr\)\)/u);
-  assert.match(stylesSource, /\.preview-column\s*\{[\s\S]*min-width:\s*var\(--studio-preview-column-min\);[\s\S]*display:\s*flex;[\s\S]*flex-direction:\s*column;[\s\S]*overflow-x:\s*hidden;[\s\S]*overflow-y:\s*auto;/u);
+
+  const electronMinWidth = readPxValue(electronSource, /minWidth:\s*(\d+)/u, "Electron minWidth");
+  const sidebarWidth = readPxValue(stylesSource, /--sidebar-width:\s*(\d+)px;/u, "sidebar width");
+  const splitterSize = readPxValue(stylesSource, /--splitter-size:\s*(\d+)px;/u, "splitter size");
+  const gridPadding = readPxValue(readCssBlock(stylesSource, ".grid,\n.firmware-grid,\n.controller-grid"), /padding:\s*(\d+)px;/u, "grid padding");
+  const studioColumnMinimums = readStudioColumnMinimums(appSource);
+  const studioMinimumWidth =
+    studioColumnMinimums.reduce((sum, value) => sum + value, 0)
+    + splitterSize * 2
+    + gridPadding * 2;
+  const workspaceMinimumWidth = electronMinWidth - sidebarWidth;
+
+  assert.deepEqual(studioColumnMinimums, [260, 300, 150]);
+  assert.ok(
+    studioMinimumWidth <= workspaceMinimumWidth,
+    `Studio minimum ${studioMinimumWidth}px exceeds workspace minimum ${workspaceMinimumWidth}px`,
+  );
+
+  assert.match(stylesSource, /--studio-preview-column-min:\s*300px;/u);
+  assert.match(stylesSource, /\.workspace-content\s*\{[\s\S]*overflow:\s*hidden;/u);
+  assert.doesNotMatch(stylesSource, /\.workspace-content\s*\{[\s\S]*overflow-x:\s*auto;/u);
+  assert.match(stylesSource, /\.page\[data-page="studio"\]\s*\{[\s\S]*width:\s*100%;[\s\S]*min-width:\s*0;[\s\S]*overflow:\s*hidden;/u);
+  assert.doesNotMatch(stylesSource, /\.page\[data-page="studio"\]\s*\{[\s\S]*width:\s*max-content;/u);
+  assert.match(stylesSource, /\.grid\s*\{[\s\S]*width:\s*100%;[\s\S]*min-width:\s*0;[\s\S]*minmax\(260px,\s*var\(--layout-studio-col-1,\s*0\.95fr\)\)[\s\S]*minmax\(var\(--studio-preview-column-min\),\s*var\(--layout-studio-col-2,\s*1fr\)\)[\s\S]*minmax\(150px,\s*var\(--layout-studio-col-3,\s*0\.82fr\)\)/u);
+  assert.doesNotMatch(stylesSource, /\.grid\s*\{[\s\S]*width:\s*max-content;/u);
+  assert.match(stylesSource, /\.preview-column\s*\{[\s\S]*min-width:\s*0;[\s\S]*display:\s*flex;[\s\S]*flex-direction:\s*column;[\s\S]*overflow-x:\s*hidden;[\s\S]*overflow-y:\s*auto;/u);
   assert.match(stylesSource, /\.panel-preview,\s*\.panel-official-palette\s*\{[\s\S]*flex:\s*0 0 auto;[\s\S]*overflow:\s*visible;/u);
   assert.match(stylesSource, /\.panel-preview\s*\{[\s\S]*display:\s*flex;[\s\S]*flex-direction:\s*column;/u);
-  assert.match(stylesSource, /\.preview-frame\s*\{[\s\S]*width:\s*calc\(520px \+ 24px\);[\s\S]*height:\s*calc\(520px \+ 24px\);/u);
-  assert.match(stylesSource, /\.preview-canvas\s*\{[\s\S]*width:\s*520px;/u);
-  assert.match(stylesSource, /\.preview-canvas\s*\{[\s\S]*height:\s*520px;/u);
+  assert.match(stylesSource, /\.preview-frame\s*\{[\s\S]*width:\s*min\(100%,\s*calc\(520px \+ 24px\)\);[\s\S]*max-width:\s*100%;[\s\S]*aspect-ratio:\s*1;/u);
+  assert.match(stylesSource, /\.preview-canvas\s*\{[\s\S]*width:\s*100%;[\s\S]*max-width:\s*520px;[\s\S]*aspect-ratio:\s*1;/u);
+  assert.doesNotMatch(stylesSource, /\.preview-canvas\s*\{[\s\S]*height:\s*520px;/u);
   assert.match(stylesSource, /\.preview-canvas > img\s*\{[\s\S]*object-fit:\s*fill;/u);
   assert.doesNotMatch(stylesSource, /--preview-canvas-size/u);
   assert.doesNotMatch(appSource, /computePreviewCanvasSize/u);
   assert.doesNotMatch(appSource, /initializePreviewCanvasLayout/u);
   assert.doesNotMatch(appSource, /schedulePreviewCanvasLayoutSync/u);
-  assert.match(appSource, /const STUDIO_PREVIEW_COLUMN_MIN_PX = 568;/u);
-  assert.match(appSource, /minPixels:\s*\[250,\s*STUDIO_PREVIEW_COLUMN_MIN_PX,\s*190\]/u);
+  assert.match(appSource, /const STUDIO_PREVIEW_COLUMN_MIN_PX = 300;/u);
+  assert.match(appSource, /minPixels:\s*\[260,\s*STUDIO_PREVIEW_COLUMN_MIN_PX,\s*150\]/u);
 });
 
 test("page switches reset the shared preview column scroll state", async () => {


### PR DESCRIPTION
## Summary
- Keep the studio page and grid constrained to the workspace instead of expanding with `max-content`.
- Reduce the studio panel minimum widths so the three-column layout fits within the 980px Electron minimum window.
- Make the preview frame and canvas responsive while preserving a 520px maximum canvas size, and update the layout regression test.

## Testing
- `node --import tsx --test apps/desktop/test/preview-layout.test.ts`
- `npm run check`
- `npm run test:desktop`
- Playwright viewport checks at `980x720`, `1280x860`, and `1440x900`: `.workspace-content` horizontal overflow was `0`, with the right-side preview, script, and log panels inside the viewport.